### PR TITLE
Add GT New Horizons as a first-class modpack platform, with per-version Java selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each push is cut as a new release with
 its own dated entry.
 
+## [Unreleased]
+
+### Added
+
+- **GT New Horizons is now a first-class modpack.** The creation wizard's "From modpack" tab has a
+  dedicated GTNH card: pick a pack version (stable by default, betas behind a toggle) and the panel
+  pins it, sizes the server for it, and installs it in one task. Pinning means restarts can never
+  silently upgrade the pack — the same rule every other modpack already followed.
+- **GTNH servers pick their own Java.** GTNH's release index states the highest Java each pack
+  version supports, so the panel runs 2.8.0+ on **Java 25** and older releases on Java 21 or 17
+  automatically, instead of stranding a 1.7.10 pack on Java 8. Overriding the image tag by hand
+  still wins.
+- GTNH packs take part in update checks (respecting the channel they were pinned from), blueprint
+  export/import, and the guarded upgrade flow with pre-update backup and rollback.
+
+### Fixed
+
+- Pack upgrades no longer time out at 10 minutes for GTNH, which downloads a ~1–2 GB server pack
+  and builds a several-hundred-mod world on first boot; it now gets 30 minutes before the upgrade
+  is treated as failed.
+
 ## [0.9.6] - 2026-08-10
 
 Fixes the item browser (used for giving/placing items) coming up empty on vanilla-ish

--- a/README.md
+++ b/README.md
@@ -383,6 +383,13 @@ form validates it.
 The image does **not** pick Java for you. The panel maps MC version → image tag
 (`java8/16/17/21/latest`) with a per-server override in Advanced settings.
 
+### GT New Horizons
+
+GTNH is installed from its own release index rather than CurseForge, and the panel always pins an
+exact pack version. Java is chosen per version from the index's own `maxJavaVersion`: GTNH 2.8.0 and
+later run on **Java 25** via the pack's bundled lwjgl3ify patches, older releases on Java 21 or 17.
+Budget **6 GB of heap and 20 GB of disk** to start — the wizard raises both for you.
+
 ### Disk quotas are panel-enforced
 
 Docker can't cap bind-mount disk usage, so a background size-indexer walks `./data`, caches sizes in

--- a/public/js/pages/modpacks.js
+++ b/public/js/pages/modpacks.js
@@ -298,7 +298,7 @@ function initPage() {
   document.getElementById('packs-installed')?.addEventListener('click', async (e) => {
     const card = e.target.closest('[data-pack-card]');
     if (!card) return;
-    const { serverId, serverName, packName, current, latest } = card.dataset;
+    const { serverId, serverName, packName, current, latest, versionId } = card.dataset;
 
     if (e.target.closest('[data-pack-check]')) {
       try {
@@ -327,7 +327,11 @@ function initPage() {
       try {
         const result = await runTask({
           title: `Upgrading ${packName} on ${serverName}`,
-          start: async () => (await postJSON(`/api/servers/${serverId}/pack/upgrade`, {})).taskId,
+          // Post the exact version the card showed as "latest" (belt and braces —
+          // the server independently re-resolves and honours the pin's channel;
+          // this just makes the request name what the user actually confirmed).
+          start: async () =>
+            (await postJSON(`/api/servers/${serverId}/pack/upgrade`, versionId ? { versionId } : {})).taskId,
         });
         if (result && result.ok === false) {
           toast(

--- a/public/js/pages/wizard.js
+++ b/public/js/pages/wizard.js
@@ -864,6 +864,20 @@ function initModBrowser() {
 
 // ---- From-modpack tab: search → select → pin a version -----------------------
 
+/** Raise the RAM/disk sliders to a pack's minimum — never lower what's already set. */
+function raiseResourceFloor(minHeapMb, minQuotaGb) {
+  for (const [id, min] of [
+    ['wz-ram', minHeapMb],
+    ['wz-quota', minQuotaGb],
+  ]) {
+    const el = document.getElementById(id);
+    if (el && Number(el.value) < min) {
+      el.value = String(min);
+      el.dispatchEvent(new Event('input', { bubbles: true })); // refresh the readout
+    }
+  }
+}
+
 function initPackPicker() {
   const panel = document.getElementById('wz-modpack');
   if (!panel) return null;
@@ -874,6 +888,17 @@ function initPackPicker() {
   const summaryEl = document.getElementById('wz-pack-summary');
   const versionSel = document.getElementById('wz-pack-version');
   const detailsBtn = document.getElementById('wz-pack-details-btn');
+  const gtnhBtn = document.getElementById('wz-gtnh-pick');
+  const betaRow = document.getElementById('wz-gtnh-beta-row');
+  const betaBox = document.getElementById('wz-gtnh-beta');
+
+  gtnhBtn?.addEventListener('click', () => withBusy(gtnhBtn, () => select('gtnh', 'gtnh')));
+
+  // Beta is a pure client-side filter over the already-resolved list: the pin's
+  // channel comes from whichever version is actually chosen, so no round trip.
+  betaBox?.addEventListener('change', () => {
+    if (selection?.platform === 'gtnh') fillVersions(selection.resolved);
+  });
 
   let platform = 'modrinth';
   let lastResults = [];
@@ -976,34 +1001,51 @@ function initPackPicker() {
     try {
       const pack = await resolve(ref, versionId);
       selection = { platform: pf, ref: pack.projectRef, resolved: pack };
-      syncing = true;
-      versionSel.innerHTML = '';
-      const versions =
-        pack.allVersions && pack.allVersions.length
-          ? pack.allVersions
-          : [{ id: pack.versionId, name: pack.versionName, type: 'release' }];
-      for (const v of versions) {
-        const opt = document.createElement('option');
-        opt.value = v.id;
-        opt.textContent = `${v.name}${v.type && v.type !== 'release' ? ` (${v.type})` : ''}`;
-        if (v.date) opt.dataset.desc = String(v.date).slice(0, 10);
-        versionSel.appendChild(opt);
-      }
-      if (![...versionSel.options].some((o) => o.value === pack.versionId)) {
-        const opt = document.createElement('option');
-        opt.value = pack.versionId;
-        opt.textContent = pack.versionName;
-        versionSel.insertBefore(opt, versionSel.firstChild);
-      }
-      versionSel.value = pack.versionId;
-      versionSel.dispatchEvent(new Event('change', { bubbles: true })); // sync the styled trigger
-      syncing = false;
+      const isGtnh = pf === 'gtnh';
+      betaRow?.classList.toggle('hidden', !isGtnh);
+      betaRow?.classList.toggle('flex', isGtnh);
+      // GTNH has no project API behind the details modal — the summary carries
+      // a changelog link instead.
+      detailsBtn.classList.toggle('hidden', isGtnh);
+      if (isGtnh) raiseResourceFloor(6144, 20);
+      fillVersions(pack);
       renderSummary();
     } catch (err) {
       selection = null;
       summaryEl.innerHTML = `<span class="text-sm text-danger">${escapeHtml(err.message)}</span>`;
       toast(err.message, { kind: 'error', timeout: 9000 });
     }
+  }
+
+  function fillVersions(pack) {
+    syncing = true;
+    versionSel.innerHTML = '';
+    const isGtnh = pack.platform === 'gtnh';
+    let versions =
+      pack.allVersions && pack.allVersions.length
+        ? pack.allVersions
+        : [{ id: pack.versionId, name: pack.versionName, type: 'release' }];
+    // GTNH betas are listed but hidden until asked for. Never hide the version
+    // that is actually selected, or the select would silently jump to another.
+    if (isGtnh && !betaBox?.checked) {
+      versions = versions.filter((v) => v.type !== 'beta' || v.id === pack.versionId);
+    }
+    for (const v of versions) {
+      const opt = document.createElement('option');
+      opt.value = v.id;
+      opt.textContent = `${v.name}${v.type && v.type !== 'release' ? ` (${v.type})` : ''}`;
+      if (v.date) opt.dataset.desc = String(v.date).slice(0, 10);
+      versionSel.appendChild(opt);
+    }
+    if (![...versionSel.options].some((o) => o.value === pack.versionId)) {
+      const opt = document.createElement('option');
+      opt.value = pack.versionId;
+      opt.textContent = pack.versionName;
+      versionSel.insertBefore(opt, versionSel.firstChild);
+    }
+    versionSel.value = pack.versionId;
+    versionSel.dispatchEvent(new Event('change', { bubbles: true })); // sync the styled trigger
+    syncing = false;
   }
 
   let resolveSeq = 0; // rapid version changes: a slow earlier resolve must not win
@@ -1034,12 +1076,18 @@ function initPackPicker() {
     if (p.mcVersion) bits.push(`Minecraft ${escapeHtml(p.mcVersion)}`);
     const loader = (p.loaders || []).find((l) => ['fabric', 'forge', 'neoforge', 'quilt'].includes(l));
     if (loader) bits.push(escapeHtml(loader));
+    // Server-resolved so the browser never re-implements the java matrix.
+    if (p.javaTag) bits.push(`Java ${escapeHtml(p.javaTag.replace('java', ''))}`);
+    const changelog = p.changelogUrl
+      ? `<a class="text-link hover:underline" href="${escapeHtml(p.changelogUrl)}" target="_blank" rel="noopener">changelog</a>`
+      : '';
     summaryEl.innerHTML = `
       ${packIconHtml(p.iconUrl, 'size-10')}
       <div class="min-w-0 flex-1">
         <div class="truncate font-semibold">${escapeHtml(p.projectName)}</div>
         <div class="text-xs text-ink-faint">${bits.join(' · ') || 'Loader & MC version come from the pack'} — the pack dictates flavor and version</div>
       </div>
+      <span class="shrink-0 space-x-2 text-xs">${changelog}</span>
       <span class="chip shrink-0">pinned @ ${escapeHtml(p.versionName)}</span>`;
   }
 

--- a/public/js/pages/wizard.js
+++ b/public/js/pages/wizard.js
@@ -933,6 +933,12 @@ function initPackPicker() {
   async function search() {
     const term = q.value.trim();
     if (!term) return;
+    // GTNH isn't searchable — /api/packs/search only knows modrinth/curseforge. Fall
+    // back to the picker's original default so the request (and the chips) stay truthful.
+    if (platform === 'gtnh') {
+      platform = 'modrinth';
+      syncChips();
+    }
     resultsEl.classList.remove('hidden');
     resultsEl.innerHTML = '<div class="p-3 text-center text-sm text-ink-faint">Searching…</div>';
     try {

--- a/public/js/pages/wizard.js
+++ b/public/js/pages/wizard.js
@@ -871,7 +871,13 @@ function raiseResourceFloor(minHeapMb, minQuotaGb) {
     ['wz-quota', minQuotaGb],
   ]) {
     const el = document.getElementById(id);
-    if (el && Number(el.value) < min) {
+    if (!el) continue;
+    // data-zero="off" sliders (the quota slider) treat 0 as "unlimited", not the
+    // smallest possible value — raising it to a floor would silently turn a
+    // deliberate "no quota" choice into a 20 GB cap, tightening the one setting
+    // most likely to matter for GTNH's disk footprint.
+    if (el.dataset.zero === 'off' && Number(el.value) === 0) continue;
+    if (Number(el.value) < min) {
       el.value = String(min);
       el.dispatchEvent(new Event('input', { bubbles: true })); // refresh the readout
     }
@@ -988,11 +994,15 @@ function initPackPicker() {
     }
   });
 
-  async function resolve(ref, versionId) {
+  // pf defaults to the module-level `platform`, but callers that already have a
+  // trustworthy platform (the version-change handler below has selection.platform)
+  // must pass it explicitly — `platform` drifts once a GTNH pick is followed by a
+  // search (or the platform-chip handler runs), and posting the stale value 404s.
+  async function resolve(ref, versionId, pf = platform) {
     const res = await fetch('/api/packs/resolve', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ platform, ref, ...(versionId ? { versionId } : {}) }),
+      body: JSON.stringify({ platform: pf, ref, ...(versionId ? { versionId } : {}) }),
     });
     const data = await res.json();
     if (!res.ok || !data.ok) throw new Error(data.error || 'Could not resolve the pack');
@@ -1061,7 +1071,7 @@ function initPackPicker() {
     const seq = ++resolveSeq;
     summaryEl.innerHTML = '<span class="text-sm text-ink-faint">Resolving pack versions…</span>';
     try {
-      const pack = await resolve(selection.ref, versionId);
+      const pack = await resolve(selection.ref, versionId, selection.platform);
       if (seq !== resolveSeq) return;
       selection.resolved = pack;
       renderSummary();

--- a/src/blueprints/index.js
+++ b/src/blueprints/index.js
@@ -117,7 +117,7 @@ const manifestSchema = z.object({
   }),
   pack: z
     .object({
-      platform: z.enum(['curseforge', 'modrinth', 'ftb']),
+      platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
       projectRef: z.string().min(1).max(400),
       projectName: z.string().max(200).default(''),
       versionId: z.string().min(1).max(60),

--- a/src/config/field-catalog/general.js
+++ b/src/config/field-catalog/general.js
@@ -213,7 +213,7 @@ module.exports = [
     key: 'javaTag',
     scope: 'panel',
     label: 'Java version (image tag)',
-    help: "Which Java runtime image the server runs on. Auto picks the right one for your Minecraft version — and for GT New Horizons, the newest Java the pinned pack version supports. Override only for special cases like old Forge (needs Java 8) or mods that break on newer Java. Forcing a GTNH server to Java 8 makes the image install GTNH's legacy Java 8 server pack instead of the faster lwjgl3ify one.",
+    help: 'Which Java runtime image the server runs on. Auto picks the right one for your Minecraft version — and for GT New Horizons, the newest Java the pinned pack version supports. Override only for special cases like old Forge (needs Java 8) or mods that break on newer Java. Forcing a GTNH server to Java 8 makes the image install GTNH’s legacy Java 8 server pack instead of the faster lwjgl3ify one.',
     type: 'enum',
     default: '',
     options: [

--- a/src/config/field-catalog/general.js
+++ b/src/config/field-catalog/general.js
@@ -213,7 +213,7 @@ module.exports = [
     key: 'javaTag',
     scope: 'panel',
     label: 'Java version (image tag)',
-    help: 'Which Java runtime image the server runs on. Auto picks the right one for your Minecraft version; override only for special cases like old Forge (needs Java 8) or mods that break on newer Java.',
+    help: "Which Java runtime image the server runs on. Auto picks the right one for your Minecraft version — and for GT New Horizons, the newest Java the pinned pack version supports. Override only for special cases like old Forge (needs Java 8) or mods that break on newer Java. Forcing a GTNH server to Java 8 makes the image install GTNH's legacy Java 8 server pack instead of the faster lwjgl3ify one.",
     type: 'enum',
     default: '',
     options: [

--- a/src/config/field-catalog/packs.js
+++ b/src/config/field-catalog/packs.js
@@ -411,11 +411,11 @@ module.exports = [
     key: 'SKIP_GTNH_UPDATE_CHECK',
     scope: 'env',
     label: 'Skip the image’s GTNH update check',
-    help: 'Stops the container checking for newer GTNH releases on every boot. The panel sets this because it pins the pack version itself and owns the update flow.',
+    help: 'Stops the container comparing the installed pack against GTNH_PACK_VERSION on boot. Leave off: the check is also the INSTALLER, so skipping it on a server whose pack hasn’t installed yet means the pack never downloads and the server crash-loops on missing files. The pinned version already prevents surprise upgrades.',
     type: 'boolean',
+    default: false,
     mode: 'advanced',
     section: 'packs',
-    hidden: true,
     requiresRestart: true,
   },
   {

--- a/src/config/field-catalog/packs.js
+++ b/src/config/field-catalog/packs.js
@@ -410,7 +410,7 @@ module.exports = [
   {
     key: 'SKIP_GTNH_UPDATE_CHECK',
     scope: 'env',
-    label: "Skip the image's GTNH update check",
+    label: 'Skip the image’s GTNH update check',
     help: 'Stops the container checking for newer GTNH releases on every boot. The panel sets this because it pins the pack version itself and owns the update flow.',
     type: 'boolean',
     mode: 'advanced',
@@ -421,7 +421,7 @@ module.exports = [
   {
     key: 'GTNH_DELETE_BACKUPS',
     scope: 'env',
-    label: "Delete GTNH's own backups on update",
+    label: 'Delete GTNH’s own backups on update',
     help: 'Removes the backup copies the GTNH updater leaves behind in the server folder. The panel takes its own backups before any pack upgrade, so this mainly saves disk.',
     type: 'boolean',
     default: false,

--- a/src/config/field-catalog/packs.js
+++ b/src/config/field-catalog/packs.js
@@ -394,6 +394,42 @@ module.exports = [
     requiresRestart: true,
   },
 
+  // --- GT New Horizons ---
+  {
+    key: 'GTNH_PACK_VERSION',
+    scope: 'env',
+    label: 'GTNH pack version',
+    help: 'The exact GT New Horizons release to install. Managed by the modpack installer UI — the panel always pins a concrete version so restarts never upgrade the pack behind your back.',
+    type: 'text',
+    mode: 'advanced',
+    section: 'packs',
+    hidden: true,
+    note: 'Managed by the modpack installer UI',
+    requiresRestart: true,
+  },
+  {
+    key: 'SKIP_GTNH_UPDATE_CHECK',
+    scope: 'env',
+    label: "Skip the image's GTNH update check",
+    help: 'Stops the container checking for newer GTNH releases on every boot. The panel sets this because it pins the pack version itself and owns the update flow.',
+    type: 'boolean',
+    mode: 'advanced',
+    section: 'packs',
+    hidden: true,
+    requiresRestart: true,
+  },
+  {
+    key: 'GTNH_DELETE_BACKUPS',
+    scope: 'env',
+    label: "Delete GTNH's own backups on update",
+    help: 'Removes the backup copies the GTNH updater leaves behind in the server folder. The panel takes its own backups before any pack upgrade, so this mainly saves disk.',
+    type: 'boolean',
+    default: false,
+    mode: 'advanced',
+    section: 'packs',
+    requiresRestart: true,
+  },
+
   // --- Dangerous cleanup ---
   {
     key: 'REMOVE_OLD_MODS',

--- a/src/db/migrations/008_gtnh_pack.js
+++ b/src/db/migrations/008_gtnh_pack.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// GTNH pins carry two facts the other pack platforms don't have: the highest
+// Java the pinned pack version supports (which decides the container image tag)
+// and the release channel it came from (which stops the update checker from
+// offering a beta to a server that deliberately tracks stable). NULL for
+// CurseForge/Modrinth/FTB pins, which have neither concept.
+
+function up(db) {
+  db.exec(`
+    ALTER TABLE server_packs ADD COLUMN max_java_version INTEGER;
+    ALTER TABLE server_packs ADD COLUMN channel TEXT;
+  `);
+}
+
+module.exports = { up };

--- a/src/services/gtnhApi.js
+++ b/src/services/gtnhApi.js
@@ -91,7 +91,12 @@ async function fetchIndex() {
   if (!res.ok) {
     return stale() || Promise.reject(httpError(502, `GTNH download server answered HTTP ${res.status}`));
   }
-  const raw = await res.json();
+  let raw;
+  try {
+    raw = await res.json();
+  } catch (err) {
+    return stale() || Promise.reject(httpError(502, `GTNH index is malformed JSON (${err.message})`));
+  }
   db.run(
     `INSERT INTO api_cache (key, value_json, fetched_at) VALUES (?, ?, datetime('now'))
      ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,

--- a/src/services/gtnhApi.js
+++ b/src/services/gtnhApi.js
@@ -43,16 +43,16 @@ function safeChangelogUrl(description) {
  */
 function normalizeIndex(raw) {
   if (!raw || typeof raw !== 'object') return [];
+  // No serverUrl here on purpose: the itzg image downloads the pack itself,
+  // keyed by GTNH_PACK_VERSION — the panel never fetches the archive.
   return Object.entries(raw).map(([version, entry]) => {
     const e = entry || {};
-    const server = e.server || {};
     return {
       version,
       channel: /beta/i.test(String(e.title || '')) ? 'beta' : 'stable',
       releaseDate: e.releaseDate || null,
       maxJavaVersion: Number.isInteger(e.maxJavaVersion) ? e.maxJavaVersion : null,
       changelogUrl: safeChangelogUrl(e.description),
-      serverUrl: server.java17_2XUrl || server.java8Url || null,
     };
   });
 }

--- a/src/services/gtnhApi.js
+++ b/src/services/gtnhApi.js
@@ -1,0 +1,121 @@
+'use strict';
+
+// GT New Horizons release-index client.
+//
+// GTNH is not served by the Modrinth or CurseForge APIs — its releases are
+// published as a single JSON index, the same one the itzg image resolves
+// against. The index is an OBJECT keyed by version string and ordered
+// newest-first; we preserve that order rather than inventing a comparator,
+// because beta suffixes ("2.9.0-beta-2") make string ordering unreliable.
+
+const httpError = require('../utils/httpError');
+const db = require('../db');
+
+const INDEX_URL = 'https://downloads.gtnewhorizons.com/versions.json';
+// NOT cosmetic: the download host answers HTTP 403 to requests with no User-Agent.
+const UA = 'MinecraftServerManager/0.1 (self-hosted panel; contact via repo)';
+const CACHE_KEY = 'gtnh:versions';
+const TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Pull the changelog link out of an entry's HTML blurb. The index is remote
+ * content, so only an https github.com link is trusted enough to render.
+ * @param {string} description
+ * @returns {string|null}
+ */
+function safeChangelogUrl(description) {
+  const match = /href="([^"]+)"/i.exec(String(description || ''));
+  if (!match) return null;
+  try {
+    const url = new URL(match[1]);
+    if (url.protocol !== 'https:') return null;
+    if (url.hostname !== 'github.com' && !url.hostname.endsWith('.github.com')) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Raw index object → normalized entries, newest-first.
+ * Pure: no network, no db — this is the part under test.
+ * @param {any} raw
+ */
+function normalizeIndex(raw) {
+  if (!raw || typeof raw !== 'object') return [];
+  return Object.entries(raw).map(([version, entry]) => {
+    const e = entry || {};
+    const server = e.server || {};
+    return {
+      version,
+      channel: /beta/i.test(String(e.title || '')) ? 'beta' : 'stable',
+      releaseDate: e.releaseDate || null,
+      maxJavaVersion: Number.isInteger(e.maxJavaVersion) ? e.maxJavaVersion : null,
+      changelogUrl: safeChangelogUrl(e.description),
+      serverUrl: server.java17_2XUrl || server.java8Url || null,
+    };
+  });
+}
+
+/**
+ * @param {any} entries
+ * @param {{includeBeta?: boolean}} opts
+ */
+function filterVersions(entries, { includeBeta = false } = {}) {
+  return includeBeta ? entries : entries.filter((e) => e.channel === 'stable');
+}
+
+/**
+ * @param {any} entries
+ * @param {{includeBeta?: boolean}} opts
+ */
+function pickLatest(entries, { includeBeta = false } = {}) {
+  return filterVersions(entries, { includeBeta })[0] || null;
+}
+
+/** Fetch + cache the index. Serves the stale copy rather than failing. */
+async function fetchIndex() {
+  const cached = db.get('SELECT value_json, fetched_at FROM api_cache WHERE key = ?', CACHE_KEY);
+  const stale = () => (cached ? normalizeIndex(JSON.parse(cached.value_json)) : null);
+  if (cached && Date.now() - Date.parse(cached.fetched_at + 'Z') < TTL_MS) return stale();
+
+  let res;
+  try {
+    res = await fetch(INDEX_URL, {
+      headers: { 'User-Agent': UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(15000),
+    });
+  } catch (err) {
+    return stale() || Promise.reject(httpError(502, `Could not reach the GTNH download server (${err.message})`));
+  }
+  if (!res.ok) {
+    return stale() || Promise.reject(httpError(502, `GTNH download server answered HTTP ${res.status}`));
+  }
+  const raw = await res.json();
+  db.run(
+    `INSERT INTO api_cache (key, value_json, fetched_at) VALUES (?, ?, datetime('now'))
+     ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,
+    CACHE_KEY,
+    JSON.stringify(raw)
+  );
+  return normalizeIndex(raw);
+}
+
+/** @param {{includeBeta?: boolean}} [opts] */
+async function listVersions({ includeBeta = false } = {}) {
+  return filterVersions(await fetchIndex(), { includeBeta });
+}
+
+/** One version by exact key. Unknown keys are a 404 — never passed to container env. */
+async function getVersion(version) {
+  const entry = (await fetchIndex()).find((e) => e.version === version);
+  if (!entry) throw httpError(404, `Unknown GTNH pack version: ${version}`);
+  return entry;
+}
+
+/** @param {{includeBeta?: boolean}} [opts] */
+async function latest({ includeBeta = false } = {}) {
+  return pickLatest(await fetchIndex(), { includeBeta });
+}
+
+module.exports = { normalizeIndex, filterVersions, pickLatest, listVersions, getVersion, latest, INDEX_URL };

--- a/src/services/javaMatrix.js
+++ b/src/services/javaMatrix.js
@@ -10,11 +10,29 @@ function parseVersion(v) {
   return { major: +m[1], minor: +m[2], patch: +(m[3] || 0) };
 }
 
+// GTNH is a 1.7.10 pack that also runs on modern Java via its bundled lwjgl3ify
+// patches, and its release index states the highest Java each version supports.
+// Ladder down to the newest tag the panel actually ships that fits under the cap.
+const GTNH_JAVA_LADDER = [
+  { min: 25, tag: 'java25' },
+  { min: 21, tag: 'java21' },
+  { min: 17, tag: 'java17' },
+];
+
 /**
  * @param {string} mcVersion 'LATEST' | 'SNAPSHOT' | '1.20.4' | '26w02a'…
  * @param {string} type      itzg TYPE (FORGE needs java8 below 1.18)
+ * @param {object} options   { maxJavaVersion } — GTNH-specific cap
  */
-function pickJavaTag(mcVersion, type = 'VANILLA') {
+function pickJavaTag(mcVersion, type = 'VANILLA', { maxJavaVersion = null } = {}) {
+  // GTNH: the pinned pack version decides, not the 1.7.10 → java8 rule below.
+  // Unknown cap (no pin yet, or the index was unreachable) → java17, which every
+  // version in the GTNH index supports.
+  if (type === 'GTNH') {
+    const cap = Number.isInteger(maxJavaVersion) ? maxJavaVersion : 17;
+    if (cap < 17) return 'java8';
+    return (GTNH_JAVA_LADDER.find((step) => cap >= step.min) || { tag: 'java17' }).tag;
+  }
   // LATEST/SNAPSHOT and Mojang's 2026+ version scheme (e.g. "26.2") need the
   // newest Java the image ships (:latest tag) — verified live: 26.x class
   // files are version 69 (Java 25), which java21 refuses to load.

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -161,12 +161,13 @@ async function applyPack(serverId, resolved, { actor = 'system', force = false }
       : [type, JSON.stringify(env), serverId])
   );
   db.run(
-    `INSERT INTO server_packs (server_id, platform, project_ref, project_name, pinned_version_id, pinned_version_name, previous_version_id, previous_version_name)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO server_packs (server_id, platform, project_ref, project_name, pinned_version_id, pinned_version_name, previous_version_id, previous_version_name, max_java_version, channel)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(server_id) DO UPDATE SET
        platform = excluded.platform, project_ref = excluded.project_ref, project_name = excluded.project_name,
        pinned_version_id = excluded.pinned_version_id, pinned_version_name = excluded.pinned_version_name,
        previous_version_id = excluded.previous_version_id, previous_version_name = excluded.previous_version_name,
+       max_java_version = excluded.max_java_version, channel = excluded.channel,
        installed_at = datetime('now')`,
     serverId,
     resolved.platform,
@@ -175,7 +176,9 @@ async function applyPack(serverId, resolved, { actor = 'system', force = false }
     resolved.versionId,
     resolved.versionName,
     previous ? previous.pinned_version_id : null,
-    previous ? previous.pinned_version_name : null
+    previous ? previous.pinned_version_name : null,
+    resolved.maxJavaVersion ?? null,
+    resolved.channel ?? null
   );
   recordEvent({
     serverId,

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -18,7 +18,7 @@ const { pickJavaTag } = require('./javaMatrix');
 
 /**
  * Resolve a pack reference to install candidates.
- * platform: 'curseforge' | 'modrinth' | 'ftb'
+ * platform: 'curseforge' | 'modrinth' | 'ftb' | 'gtnh'
  * ref: slug/URL/id — versionId optional (null → resolve latest now, then pin).
  */
 /**
@@ -268,6 +268,9 @@ async function latestFor(serverId) {
       projectName: pack.project_name,
       projectRef: pack.project_ref,
       platform: pack.platform,
+      // A real per-version diff link (from the index entry) rather than the
+      // generic "all files" page the checker falls back to for other platforms.
+      changelogUrl: newest.changelogUrl,
     };
   }
   // Scope "latest" to the server's own MC version — otherwise the checker

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -205,6 +205,24 @@ async function applyPack(serverId, resolved, { actor = 'system', force = false }
     Object.entries(server.env).filter(([key]) => !/^(CF_|MODRINTH_|FTB_|GTNH_|SKIP_GTNH_)/.test(key))
   );
   const env = { ...cleanedEnv, ...packEnv(resolved) };
+  // GTNH's own server start scripts ship -Dfml.queryResult=confirm, and the
+  // itzg launcher path loses it. Without it, the FIRST boot after any pack
+  // version change over an existing world blocks forever on Forge's
+  // "/fml confirm" world-migration console prompt — which RCON can't reach
+  // (it isn't listening yet), so the upgrade monitor burns its whole window
+  // and reports a timeout (verified live on a 2.7.4 → 2.8.4 world). The panel
+  // always takes a pre-update backup, so confirming is the intended path.
+  // Merge, don't clobber: a user-set JVM_DD_OPTS keeps its own pairs.
+  const FML_CONFIRM = 'fml.queryResult=confirm';
+  if (resolved.platform === 'gtnh') {
+    const user = cleanedEnv.JVM_DD_OPTS;
+    env.JVM_DD_OPTS = user ? (user.includes(FML_CONFIRM) ? user : `${user} ${FML_CONFIRM}`) : FML_CONFIRM;
+  } else if (previous && previous.platform === 'gtnh' && env.JVM_DD_OPTS) {
+    // Leaving GTNH: take back only the panel's own token; user pairs survive.
+    const stripped = env.JVM_DD_OPTS.split(/[\s,]+/).filter((pair) => pair && pair !== FML_CONFIRM);
+    if (stripped.length) env.JVM_DD_OPTS = stripped.join(' ');
+    else delete env.JVM_DD_OPTS;
+  }
   // The TYPE lives in its own column; keep env's TYPE out of the extras.
   const type = env.TYPE;
   delete env.TYPE;

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -187,12 +187,13 @@ async function applyPack(serverId, resolved, { actor = 'system', force = false }
   }
 
   const previous = db.get('SELECT * FROM server_packs WHERE server_id = ?', serverId);
-  // Strip EVERY previous pack-selection/exclusion env var (CF_/MODRINTH_/FTB_)
+  // Strip EVERY previous pack-selection/exclusion env var (CF_/MODRINTH_/FTB_/GTNH_)
   // before merging the new pack env: switching platform (or even version)
   // must not leave stale slugs, file pins or exclusion lists behind. Unrelated
-  // user env is preserved.
+  // user env is preserved. SKIP_GTNH_ is its own prefix (not GTNH_-prefixed)
+  // because that env var name is dictated by the container image's contract.
   const cleanedEnv = Object.fromEntries(
-    Object.entries(server.env).filter(([key]) => !/^(CF_|MODRINTH_|FTB_|GTNH_)/.test(key))
+    Object.entries(server.env).filter(([key]) => !/^(CF_|MODRINTH_|FTB_|GTNH_|SKIP_GTNH_)/.test(key))
   );
   const env = { ...cleanedEnv, ...packEnv(resolved) };
   // The TYPE lives in its own column; keep env's TYPE out of the extras.

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -154,12 +154,16 @@ function packEnv(resolved) {
     return env;
   }
   if (resolved.platform === 'gtnh') {
+    // Deliberately NO SKIP_GTNH_UPDATE_CHECK here: the image's "update check"
+    // is also its INSTALLER — with the check skipped, a fresh server never
+    // downloads the pack at all and crash-loops on the missing files
+    // (verified live: "Skipping GTNH Update/Install" → "could not open
+    // `java9args.txt'"). Pinning GTNH_PACK_VERSION alone is what prevents
+    // silent upgrades: the image installs exactly the pinned version and the
+    // boot-time check just verifies the install matches the pin.
     return {
       TYPE: 'GTNH',
       GTNH_PACK_VERSION: resolved.versionId,
-      // The image runs its own update check on boot, which is redundant against
-      // a pinned version and would fight the panel for ownership of updates.
-      SKIP_GTNH_UPDATE_CHECK: 'true',
     };
   }
   return {

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -13,6 +13,8 @@ const serversService = require('./servers');
 const modrinth = require('./modrinthApi');
 const curseforge = require('./curseforgeApi');
 const modsService = require('./mods');
+const gtnhApi = require('./gtnhApi');
+const { pickJavaTag } = require('./javaMatrix');
 
 /**
  * Resolve a pack reference to install candidates.
@@ -88,6 +90,40 @@ async function resolvePack(platform, ref, { versionId = null, mcVersion } = {}) 
       mcVersion: null,
     };
   }
+  if (platform === 'gtnh') {
+    // GTNH is a single project with no search API: `ref` is the constant 'gtnh',
+    // and a pack version is its own id. The Minecraft version is hardcoded
+    // because the index does not state one — GTNH is a 1.7.10 pack by definition.
+    const all = await gtnhApi.listVersions({ includeBeta: true });
+    const entry = versionId ? await gtnhApi.getVersion(String(versionId)) : gtnhApi.pickLatest(all, {});
+    if (!entry) throw httpError(502, 'The GTNH release index returned no installable versions');
+    return {
+      platform,
+      projectRef: 'gtnh',
+      projectId: 'gtnh',
+      projectName: 'GT New Horizons',
+      iconUrl: null,
+      versionId: entry.version,
+      versionName: entry.version,
+      mcVersion: '1.7.10',
+      maxJavaVersion: entry.maxJavaVersion,
+      channel: entry.channel,
+      // Resolved here so the wizard can show the Java version without
+      // re-implementing the matrix in the browser.
+      javaTag: pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: entry.maxJavaVersion }),
+      changelogUrl: entry.changelogUrl,
+      // 'release' rather than 'stable': the version picker already suppresses
+      // the channel suffix for 'release', so GTNH options render like every
+      // other platform's with no display-code change.
+      allVersions: all.map((e) => ({
+        id: e.version,
+        name: e.version,
+        type: e.channel === 'beta' ? 'beta' : 'release',
+        date: e.releaseDate,
+        maxJavaVersion: e.maxJavaVersion,
+      })),
+    };
+  }
   throw httpError(400, `Unknown modpack platform: ${platform}`);
 }
 
@@ -111,6 +147,15 @@ function packEnv(resolved) {
     const loader = (resolved.loaders || []).find((l) => ['fabric', 'forge', 'neoforge', 'quilt'].includes(l));
     if (loader) env.MODRINTH_LOADER = loader;
     return env;
+  }
+  if (resolved.platform === 'gtnh') {
+    return {
+      TYPE: 'GTNH',
+      GTNH_PACK_VERSION: resolved.versionId,
+      // The image runs its own update check on boot, which is redundant against
+      // a pinned version and would fight the panel for ownership of updates.
+      SKIP_GTNH_UPDATE_CHECK: 'true',
+    };
   }
   return {
     TYPE: 'FTBA',
@@ -147,7 +192,7 @@ async function applyPack(serverId, resolved, { actor = 'system', force = false }
   // must not leave stale slugs, file pins or exclusion lists behind. Unrelated
   // user env is preserved.
   const cleanedEnv = Object.fromEntries(
-    Object.entries(server.env).filter(([key]) => !/^(CF_|MODRINTH_|FTB_)/.test(key))
+    Object.entries(server.env).filter(([key]) => !/^(CF_|MODRINTH_|FTB_|GTNH_)/.test(key))
   );
   const env = { ...cleanedEnv, ...packEnv(resolved) };
   // The TYPE lives in its own column; keep env's TYPE out of the extras.
@@ -205,6 +250,20 @@ async function latestFor(serverId) {
   const pack = getPack(serverId);
   if (!pack) return null;
   if (pack.platform === 'ftb') return null; // FTB API not wired for checks yet
+  if (pack.platform === 'gtnh') {
+    // Track the channel this server was pinned from: a stable server must never
+    // be offered a beta, and a beta server should see beta releases.
+    const newest = await gtnhApi.latest({ includeBeta: pack.channel === 'beta' });
+    if (!newest) return null;
+    return {
+      current: { id: pack.pinned_version_id, name: pack.pinned_version_name },
+      latest: { id: newest.version, name: newest.version },
+      updateAvailable: newest.version !== pack.pinned_version_id,
+      projectName: pack.project_name,
+      projectRef: pack.project_ref,
+      platform: pack.platform,
+    };
+  }
   // Scope "latest" to the server's own MC version — otherwise the checker
   // offers upgrades that silently cross MC versions.
   const server = serversService.getServer(serverId);

--- a/src/services/packs.js
+++ b/src/services/packs.js
@@ -32,7 +32,7 @@ function normalizeCurseforgeRef(ref) {
   return `https://www.curseforge.com/minecraft/modpacks/${s}`;
 }
 
-async function resolvePack(platform, ref, { versionId = null, mcVersion } = {}) {
+async function resolvePack(platform, ref, { versionId = null, mcVersion, includeBeta = false } = {}) {
   if (platform === 'curseforge') {
     const project = await curseforge.resolveUrl(normalizeCurseforgeRef(ref));
     const files = await curseforge.getFiles(project.modId, { mcVersion });
@@ -95,7 +95,12 @@ async function resolvePack(platform, ref, { versionId = null, mcVersion } = {}) 
     // and a pack version is its own id. The Minecraft version is hardcoded
     // because the index does not state one — GTNH is a 1.7.10 pack by definition.
     const all = await gtnhApi.listVersions({ includeBeta: true });
-    const entry = versionId ? await gtnhApi.getVersion(String(versionId)) : gtnhApi.pickLatest(all, {});
+    // includeBeta only matters when versionId is absent (pickLatest's default
+    // path) — an explicit versionId always resolves that exact entry regardless
+    // of channel. Callers that already know a pin's channel (the upgrade
+    // orchestrator) must pass it, or a beta-pinned server silently resolves to
+    // the newest stable instead of the newest beta.
+    const entry = versionId ? await gtnhApi.getVersion(String(versionId)) : gtnhApi.pickLatest(all, { includeBeta });
     if (!entry) throw httpError(502, 'The GTNH release index returned no installable versions');
     return {
       platform,

--- a/src/services/servers.js
+++ b/src/services/servers.js
@@ -110,14 +110,26 @@ function assembleEnv(server) {
   return env;
 }
 
-function resolveImage(server) {
+/**
+ * javaTagHint: a non-persisted, create-time-only fallback (see createServerImpl).
+ * At create time no server_packs row exists yet, so the pin lookup below always
+ * misses for a brand-new GTNH server — without the hint that resolves to java17,
+ * the image is pulled once, then re-pulled at the correct tag on the recreate
+ * `applyPack` schedules moments later. It's never used once a pin exists, and
+ * it never overrides an explicit `server.java_tag` (that column means "the user
+ * overrode auto" and must keep winning).
+ */
+function resolveImage(server, { javaTagHint } = {}) {
   // GTNH's Java support is a property of the pinned pack version, not of the
   // Minecraft version. Read it straight from the pin: packs.js requires this
   // module, so requiring it back would need a lazy-require cycle-breaker that a
   // single-column read doesn't justify.
   const pin =
     server.type === 'GTNH' ? db.get('SELECT max_java_version FROM server_packs WHERE server_id = ?', server.id) : null;
-  const tag = server.java_tag || pickJavaTag(server.mc_version, server.type, { maxJavaVersion: pin?.max_java_version });
+  const tag =
+    server.java_tag ||
+    (pin?.max_java_version == null && javaTagHint) ||
+    pickJavaTag(server.mc_version, server.type, { maxJavaVersion: pin?.max_java_version });
   return images.imageRef(tag);
 }
 
@@ -223,7 +235,7 @@ function createServer(input, opts = {}) {
  * On any failure before the container exists, the half-created row + data dirs
  * are rolled back so no ghost server holds ports.
  */
-async function createServerImpl(input, { actor = 'system', start = false, onProgress = () => {} } = {}) {
+async function createServerImpl(input, { actor = 'system', start = false, onProgress = () => {}, javaTagHint } = {}) {
   // Fail fast instead of shipping a crash-looping container: anything
   // CurseForge needs the API key present in the panel's store.
   const inputEnv = input.env || {};
@@ -312,7 +324,7 @@ async function createServerImpl(input, { actor = 'system', start = false, onProg
     fs.mkdirSync(dataPath('servers', id), { recursive: true });
     fs.mkdirSync(dataPath('logs', id, 'events'), { recursive: true });
 
-    const image = resolveImage(server);
+    const image = resolveImage(server, { javaTagHint });
     onProgress(`Pulling image ${image} (first time can take a few minutes)…`);
     await images.ensureImage(image, ({ current, total }) => {
       if (total) onProgress(`Downloading image: ${Math.round((current / total) * 100)}%`);

--- a/src/services/servers.js
+++ b/src/services/servers.js
@@ -111,7 +111,13 @@ function assembleEnv(server) {
 }
 
 function resolveImage(server) {
-  const tag = server.java_tag || pickJavaTag(server.mc_version, server.type);
+  // GTNH's Java support is a property of the pinned pack version, not of the
+  // Minecraft version. Read it straight from the pin: packs.js requires this
+  // module, so requiring it back would need a lazy-require cycle-breaker that a
+  // single-column read doesn't justify.
+  const pin =
+    server.type === 'GTNH' ? db.get('SELECT max_java_version FROM server_packs WHERE server_id = ?', server.id) : null;
+  const tag = server.java_tag || pickJavaTag(server.mc_version, server.type, { maxJavaVersion: pin?.max_java_version });
   return images.imageRef(tag);
 }
 

--- a/src/updates/checker.js
+++ b/src/updates/checker.js
@@ -20,7 +20,12 @@ async function checkAll({ actor = 'scheduler' } = {}) {
     try {
       const result = await packsService.latestFor(server.id);
       if (result) {
-        const changelog = result.updateAvailable ? packChangelogUrl(result.platform, result.projectRef) : null;
+        // GTNH's latestFor already surfaces a real per-version diff link off the
+        // index entry itself — prefer that over the platform-derived fallback
+        // (which, for GTNH, is only the generic changelogs directory).
+        const changelog = result.updateAvailable
+          ? result.changelogUrl || packChangelogUrl(result.platform, result.projectRef)
+          : null;
         upsertCheck('pack', server.id, result.current.name, {
           isNew: result.updateAvailable,
           latestId: result.latest.id,
@@ -129,6 +134,11 @@ function upsertCheck(subjectType, subjectId, current, { isNew, latestId, latestN
 function packChangelogUrl(platform, projectRef) {
   if (platform === 'modrinth') return `https://modrinth.com/project/${projectRef}/changelog`;
   if (platform === 'curseforge') return `https://www.curseforge.com/minecraft/modpacks/${projectRef}/files`;
+  // Fallback only: latestFor's gtnh branch normally supplies a real per-version
+  // link straight from the index entry (see checkAll above). This is the "all
+  // files" equivalent for the rare case a version's changelog href didn't pass
+  // safeChangelogUrl's github.com/https check.
+  if (platform === 'gtnh') return 'https://github.com/GTNewHorizons/DreamAssemblerXXL/tree/master/releases/changelogs';
   return null;
 }
 

--- a/src/updates/upgrade.js
+++ b/src/updates/upgrade.js
@@ -59,7 +59,15 @@ async function upgradePack(
 
   try {
     step('resolving');
-    const resolved = await packsService.resolvePack(pack.platform, pack.project_ref, { versionId });
+    // Thread the pin's own channel through: without this, an explicit versionId-less
+    // upgrade on a beta-pinned GTNH server silently resolves to the newest STABLE
+    // (pickLatest's default), while the UI (latestFor) showed the newest BETA — a
+    // downgrade the user never confirmed. includeBeta is a no-op for every other
+    // platform/branch, which doesn't key off a stored channel.
+    const resolved = await packsService.resolvePack(pack.platform, pack.project_ref, {
+      versionId,
+      includeBeta: pack.channel === 'beta',
+    });
     if (resolved.versionId === pack.pinned_version_id) {
       throw httpError(400, `Already on ${pack.pinned_version_name} — nothing to upgrade`);
     }

--- a/src/updates/upgrade.js
+++ b/src/updates/upgrade.js
@@ -112,8 +112,10 @@ async function upgradePack(
 
     step('monitoring');
     // CF/Modrinth installs download the whole pack on first boot — give them
-    // twice the window.
-    const timeoutMs = ['curseforge', 'modrinth'].includes(pack.platform) ? 20 * 60 * 1000 : 10 * 60 * 1000;
+    // twice the window. GTNH downloads a ~1-2 GB server pack and then builds a
+    // 1.7.10 world with several hundred mods, which routinely outlasts both.
+    const INSTALL_TIMEOUTS_MS = { gtnh: 30 * 60 * 1000, curseforge: 20 * 60 * 1000, modrinth: 20 * 60 * 1000 };
+    const timeoutMs = INSTALL_TIMEOUTS_MS[pack.platform] || 10 * 60 * 1000;
     const healthy = await waitForHealthy(serverId, { timeoutMs });
     const excerpt = await fetchLogs(serverId, { tail: 200 }).catch(() => '');
 

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -133,7 +133,8 @@ function createApp() {
         inc: (v) => Number(v) + 1,
         mul: (a, b) => Number(a) * Number(b),
         plural: (n, one, many) => (Number(n) === 1 ? one : many),
-        platformName: (p) => ({ modrinth: 'Modrinth', curseforge: 'CurseForge' })[p] || p,
+        platformName: (p) =>
+          ({ modrinth: 'Modrinth', curseforge: 'CurseForge', gtnh: 'GT New Horizons', ftb: 'FTB' })[p] || p,
         // Handlebars {{#if}} treats 0 as falsy, which silently drops min="0"
         // attributes and zero defaults — this helper exists for those tests.
         isDefined: (v) => v !== undefined && v !== null && v !== '',

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -430,7 +430,9 @@ const UPGRADE_STEP_LABELS = {
   stopping: 'Stopping server',
   applying: 'Re-pinning pack version',
   recreating: 'Recreating container',
-  monitoring: 'Starting & monitoring (up to 10 min)',
+  // No fixed minutes in the label: the window is per-platform (30 min for
+  // GTNH, 20 for CurseForge/Modrinth, 10 otherwise — see upgrade.js).
+  monitoring: 'Starting & monitoring the new version',
   overlay: 'Re-applying custom overlay mods',
 };
 

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -743,7 +743,11 @@ router.post(
           extraPorts: input.extraPorts,
           extraBinds: input.extraBinds,
         },
-        { actor, start: false, onProgress: (s) => t.step(s) }
+        // javaTagHint (not persisted as java_tag — that column means "user override"):
+        // at create time there's no server_packs row yet, so resolveImage() would
+        // otherwise fall back to java17 for GTNH, pull that image, then immediately
+        // re-pull the correct one when the applyPack below flags a recreate.
+        { actor, start: false, onProgress: (s) => t.step(s), javaTagHint: resolved.javaTag }
       );
       t.step(`Pinning ${resolved.projectName} @ ${resolved.versionName}`);
       // force: fresh server — there is no world yet to version-guard.

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -385,7 +385,7 @@ router.post(
   asyncHandler(async (req, res, next) => {
     const { platform, ref, versionId, mcVersion } = z
       .object({
-        platform: z.enum(['curseforge', 'modrinth', 'ftb']),
+        platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
         ref: z.string().trim().min(1).max(400),
         versionId: z.string().trim().max(60).optional(),
         mcVersion: z.string().trim().max(32).optional(),
@@ -399,7 +399,7 @@ router.post('/servers/:id/pack', async (req, res, next) => {
   try {
     const { platform, ref, versionId, force } = z
       .object({
-        platform: z.enum(['curseforge', 'modrinth', 'ftb']),
+        platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
         ref: z.string().trim().min(1).max(400),
         versionId: z.string().trim().max(60).optional(),
         force: z.coerce.boolean().optional(),
@@ -607,6 +607,8 @@ router.get(
       if (!pin) throw Object.assign(new Error('This server has no managed modpack'), { status: 404 });
       if (pin.platform === 'ftb')
         throw Object.assign(new Error('FTB pack details are not supported yet'), { status: 400 });
+      if (pin.platform === 'gtnh')
+        throw Object.assign(new Error('GTNH pack details live on the GTNH site'), { status: 400 });
       platform = pin.platform;
       ref = pin.project_ref;
       installed = {
@@ -676,7 +678,7 @@ const fromPackSchema = z
       .string()
       .regex(/^#[0-9a-fA-F]{6}$/)
       .optional(),
-    platform: z.enum(['curseforge', 'modrinth', 'ftb']),
+    platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
     ref: z.string().trim().min(1).max(400),
     versionId: z.string().trim().max(60).optional(),
     heapMb: z.coerce.number().int().min(512).max(262144).optional(),

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -442,9 +442,9 @@ router.post(
   asyncHandler((req, res, next) => {
     const { versionId, skipBackup } = z
       .object({
-        // Same shape constraint as the other pack versionId fields (finding #5) —
-        // this one wasn't in the reviewed list, but it reaches the exact same
-        // GTNH_PACK_VERSION/CF_FILE_ID/etc. container env path via upgradePack.
+        // Same shape constraint as the other pack versionId fields: this one
+        // reaches the exact same GTNH_PACK_VERSION/CF_FILE_ID/etc. container
+        // env path via upgradePack.
         versionId: z
           .string()
           .trim()

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -387,7 +387,11 @@ router.post(
       .object({
         platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
         ref: z.string().trim().min(1).max(400),
-        versionId: z.string().trim().max(60).optional(),
+        versionId: z
+          .string()
+          .trim()
+          .regex(/^[\w.-]{1,64}$/)
+          .optional(),
         mcVersion: z.string().trim().max(32).optional(),
       })
       .parse(req.body);
@@ -401,7 +405,11 @@ router.post('/servers/:id/pack', async (req, res, next) => {
       .object({
         platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
         ref: z.string().trim().min(1).max(400),
-        versionId: z.string().trim().max(60).optional(),
+        versionId: z
+          .string()
+          .trim()
+          .regex(/^[\w.-]{1,64}$/)
+          .optional(),
         force: z.coerce.boolean().optional(),
       })
       .parse(req.body);
@@ -434,7 +442,14 @@ router.post(
   asyncHandler((req, res, next) => {
     const { versionId, skipBackup } = z
       .object({
-        versionId: z.string().trim().max(60).optional(),
+        // Same shape constraint as the other pack versionId fields (finding #5) —
+        // this one wasn't in the reviewed list, but it reaches the exact same
+        // GTNH_PACK_VERSION/CF_FILE_ID/etc. container env path via upgradePack.
+        versionId: z
+          .string()
+          .trim()
+          .regex(/^[\w.-]{1,64}$/)
+          .optional(),
         skipBackup: z.coerce.boolean().optional(),
       })
       .parse(req.body);
@@ -680,7 +695,11 @@ const fromPackSchema = z
       .optional(),
     platform: z.enum(['curseforge', 'modrinth', 'ftb', 'gtnh']),
     ref: z.string().trim().min(1).max(400),
-    versionId: z.string().trim().max(60).optional(),
+    versionId: z
+      .string()
+      .trim()
+      .regex(/^[\w.-]{1,64}$/)
+      .optional(),
     heapMb: z.coerce.number().int().min(512).max(262144).optional(),
     containerMemoryMb: z.coerce.number().int().min(1024).max(524288).optional(),
     diskQuotaGb: z.coerce.number().min(0).max(16384).optional(),

--- a/src/web/viewModels.js
+++ b/src/web/viewModels.js
@@ -75,7 +75,7 @@ function packVM(serverId) {
   const pack = db.get('SELECT * FROM server_packs WHERE server_id = ?', serverId);
   if (!pack) return null;
   const check = db.get(
-    "SELECT latest_name FROM update_checks WHERE subject_type = 'pack' AND subject_id = ?",
+    "SELECT latest_version, latest_name FROM update_checks WHERE subject_type = 'pack' AND subject_id = ?",
     serverId
   );
   return {
@@ -84,6 +84,11 @@ function packVM(serverId) {
     version: pack.pinned_version_name,
     versionId: pack.pinned_version_id,
     latest: check && check.latest_name ? check.latest_name : pack.pinned_version_name,
+    // The real platform id behind `latest` (a display NAME — differs from the id
+    // for CurseForge/Modrinth). Modpacks-page "Upgrade" posts this so the request
+    // names the exact version the card showed, rather than trusting the server to
+    // re-derive "latest" itself. Same pattern as updates.hbs's data-version-id.
+    latestVersionId: check && check.latest_version ? check.latest_version : null,
   };
 }
 

--- a/test/checker-gtnh.test.js
+++ b/test/checker-gtnh.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Isolated from packs-gtnh.test.js on purpose: checker.checkAll() iterates
+// EVERY server in the DB, and that file's shared DB accumulates CurseForge/
+// Modrinth-pinned test servers whose real API calls would need network. This
+// file seeds only a single GTNH server so checkAll never attempts one.
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const app = require('./helpers/app'); // migrates the DB + gives us seedServer()
+const db = require('../src/db');
+const packs = require('../src/services/packs');
+const gtnhApi = require('../src/services/gtnhApi');
+const checker = require('../src/updates/checker');
+const rawIndex = require('./fixtures/gtnh-versions.json');
+
+function stubIndex() {
+  const entries = gtnhApi.normalizeIndex(rawIndex);
+  const realList = gtnhApi.listVersions;
+  const realGet = gtnhApi.getVersion;
+  const realLatest = gtnhApi.latest;
+  gtnhApi.listVersions = async ({ includeBeta = false } = {}) => gtnhApi.filterVersions(entries, { includeBeta });
+  gtnhApi.getVersion = async (v) => {
+    const found = entries.find((e) => e.version === v);
+    if (!found) throw Object.assign(new Error(`Unknown GTNH pack version: ${v}`), { status: 404 });
+    return found;
+  };
+  gtnhApi.latest = async ({ includeBeta = false } = {}) => gtnhApi.pickLatest(entries, { includeBeta });
+  return () => {
+    gtnhApi.listVersions = realList;
+    gtnhApi.getVersion = realGet;
+    gtnhApi.latest = realLatest;
+  };
+}
+
+test('checkAll caches the per-version GTNH changelog link, not the generic fallback', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_checkall_gtnh');
+    // Pin an older stable (2.7.4) so a newer stable (2.8.4) is available.
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.7.4' });
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+
+    await checker.checkAll({ actor: 'test' });
+
+    const check = db.get("SELECT * FROM update_checks WHERE subject_type = 'pack' AND subject_id = ?", id);
+    assert.ok(check, 'expected a cached update_checks row');
+    assert.equal(check.latest_version, '2.8.4');
+    // The 2.8.4 fixture entry's own changelog href, not the generic
+    // DreamAssemblerXXL changelogs directory checker.js falls back to.
+    assert.equal(
+      check.changelog_url,
+      'https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/master/releases/changelogs/changelog%20from%202.8.3%20to%202.8.4.md'
+    );
+  } finally {
+    restore();
+  }
+});

--- a/test/field-catalog.test.js
+++ b/test/field-catalog.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { fields, getField, SECTIONS } = require('../src/config/field-catalog');
+
+test('every field key is unique within its scope', () => {
+  const seen = new Set();
+  for (const f of fields) {
+    const id = `${f.scope}:${f.key}`;
+    assert.equal(seen.has(id), false, `duplicate catalog entry: ${id}`);
+    seen.add(id);
+  }
+});
+
+test('every field lands in a declared section', () => {
+  const ids = new Set(SECTIONS.map((s) => s.id));
+  for (const f of fields) {
+    assert.equal(ids.has(f.section), true, `${f.key} has unknown section "${f.section}"`);
+  }
+});
+
+test('the GTNH pack vars are catalogued and panel-managed', () => {
+  const version = getField('env', 'GTNH_PACK_VERSION');
+  assert.ok(version, 'GTNH_PACK_VERSION missing from the catalog');
+  assert.equal(version.section, 'packs');
+  // Panel-managed: the installer UI owns it, so it must never render as a form field.
+  assert.equal(version.hidden, true);
+  assert.equal(getField('env', 'SKIP_GTNH_UPDATE_CHECK').hidden, true);
+  assert.equal(getField('env', 'GTNH_DELETE_BACKUPS').type, 'boolean');
+});

--- a/test/field-catalog.test.js
+++ b/test/field-catalog.test.js
@@ -27,6 +27,10 @@ test('the GTNH pack vars are catalogued and panel-managed', () => {
   assert.equal(version.section, 'packs');
   // Panel-managed: the installer UI owns it, so it must never render as a form field.
   assert.equal(version.hidden, true);
-  assert.equal(getField('env', 'SKIP_GTNH_UPDATE_CHECK').hidden, true);
+  // NOT panel-set and NOT hidden: the image's check doubles as its installer,
+  // so this is a user-visible advanced toggle with an off default.
+  const skip = getField('env', 'SKIP_GTNH_UPDATE_CHECK');
+  assert.equal(skip.hidden, undefined);
+  assert.equal(skip.default, false);
   assert.equal(getField('env', 'GTNH_DELETE_BACKUPS').type, 'boolean');
 });

--- a/test/fixtures/gtnh-versions.json
+++ b/test/fixtures/gtnh-versions.json
@@ -1,0 +1,55 @@
+{
+  "2.9.0-beta-2": {
+    "title": "Beta release",
+    "description": "<a href=\"https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/master/releases/changelogs/changelog%20from%202.9.0-beta-1%20to%202.9.0-beta-2.md\">Click here to get the changelog</a>",
+    "releaseDate": "2026/07/05",
+    "maxJavaVersion": 25,
+    "server": {
+      "java8Url": "https://downloads.gtnewhorizons.com/ServerPacks/betas/GT_New_Horizons_2.9.0-beta-2_Server_Java_8.zip",
+      "java17_2XUrl": "https://downloads.gtnewhorizons.com/ServerPacks/betas/GT_New_Horizons_2.9.0-beta-2_Server_Java_17-25.zip"
+    }
+  },
+  "2.8.4": {
+    "title": "Stable release",
+    "description": "<a href=\"https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/master/releases/changelogs/changelog%20from%202.8.3%20to%202.8.4.md\">Click here to get the changelog</a>",
+    "releaseDate": "2025/12/23",
+    "maxJavaVersion": 25,
+    "server": {
+      "java8Url": "https://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_2.8.4_Server_Java_8.zip",
+      "java17_2XUrl": "https://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_2.8.4_Server_Java_17-25.zip"
+    }
+  },
+  "2.7.4": {
+    "title": "Stable release",
+    "description": "<a href=\"https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/master/releases/changelogs/changelog%20from%202.7.3%20to%202.7.4.md\">Click here to get the changelog</a>",
+    "releaseDate": "2025/04/13",
+    "maxJavaVersion": 21,
+    "server": {
+      "java8Url": "https://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_2.7.4_Server_Java_8.zip",
+      "java17_2XUrl": "https://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_2.7.4_Server_Java_17-21.zip"
+    }
+  },
+  "2.4.0": {
+    "title": "Stable release",
+    "description": "<a href=\"https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/master/releases/changelogs/older%20changelogs/changelog%20from%202.3.0%20to%202.4.0.md\">Click here to get the changelog</a>",
+    "releaseDate": "2023/09/03",
+    "maxJavaVersion": 20,
+    "server": {
+      "java8Url": "https://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_2.4.0_Server_Java_8.zip",
+      "java17_2XUrl": "https://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_2.4.0_Server_Java_17-20.zip"
+    }
+  },
+  "9.9.9-synthetic-nojava": {
+    "title": "Stable release",
+    "description": "<a href=\"https://github.com/GTNewHorizons/DreamAssemblerXXL\">changelog</a>",
+    "releaseDate": "2026/01/01",
+    "server": { "java8Url": "https://downloads.gtnewhorizons.com/ServerPacks/synthetic_Java_8.zip" }
+  },
+  "9.9.8-synthetic-badlink": {
+    "title": "Stable release",
+    "description": "<a href=\"javascript:alert(1)\">changelog</a>",
+    "releaseDate": "2026/01/02",
+    "maxJavaVersion": 25,
+    "server": { "java17_2XUrl": "https://downloads.gtnewhorizons.com/ServerPacks/synthetic_Java_17-25.zip" }
+  }
+}

--- a/test/gtnhApi.test.js
+++ b/test/gtnhApi.test.js
@@ -38,12 +38,6 @@ test('normalizeIndex accepts only https github changelog links', () => {
   assert.equal(byVersion['9.9.8-synthetic-badlink'].changelogUrl, null);
 });
 
-test('normalizeIndex prefers the modern server pack url', () => {
-  const byVersion = Object.fromEntries(gtnh.normalizeIndex(raw).map((e) => [e.version, e]));
-  assert.match(byVersion['2.8.4'].serverUrl, /Server_Java_17-25\.zip$/);
-  assert.match(byVersion['9.9.9-synthetic-nojava'].serverUrl, /Java_8\.zip$/);
-});
-
 test('normalizeIndex tolerates junk input', () => {
   assert.deepEqual(gtnh.normalizeIndex(null), []);
   assert.deepEqual(gtnh.normalizeIndex('nope'), []);

--- a/test/gtnhApi.test.js
+++ b/test/gtnhApi.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const raw = require('./fixtures/gtnh-versions.json');
+const gtnh = require('../src/services/gtnhApi');
+
+test('normalizeIndex preserves the index order (newest first)', () => {
+  const entries = gtnh.normalizeIndex(raw);
+  assert.deepEqual(
+    entries.map((e) => e.version),
+    ['2.9.0-beta-2', '2.8.4', '2.7.4', '2.4.0', '9.9.9-synthetic-nojava', '9.9.8-synthetic-badlink']
+  );
+});
+
+test('normalizeIndex maps title to a channel', () => {
+  const byVersion = Object.fromEntries(gtnh.normalizeIndex(raw).map((e) => [e.version, e]));
+  assert.equal(byVersion['2.9.0-beta-2'].channel, 'beta');
+  assert.equal(byVersion['2.8.4'].channel, 'stable');
+});
+
+test('normalizeIndex carries maxJavaVersion, null when absent', () => {
+  const byVersion = Object.fromEntries(gtnh.normalizeIndex(raw).map((e) => [e.version, e]));
+  assert.equal(byVersion['2.8.4'].maxJavaVersion, 25);
+  assert.equal(byVersion['2.7.4'].maxJavaVersion, 21);
+  assert.equal(byVersion['9.9.9-synthetic-nojava'].maxJavaVersion, null);
+});
+
+test('normalizeIndex accepts only https github changelog links', () => {
+  const byVersion = Object.fromEntries(gtnh.normalizeIndex(raw).map((e) => [e.version, e]));
+  assert.match(byVersion['2.8.4'].changelogUrl, /^https:\/\/github\.com\//);
+  assert.equal(byVersion['9.9.8-synthetic-badlink'].changelogUrl, null);
+});
+
+test('normalizeIndex prefers the modern server pack url', () => {
+  const byVersion = Object.fromEntries(gtnh.normalizeIndex(raw).map((e) => [e.version, e]));
+  assert.match(byVersion['2.8.4'].serverUrl, /Server_Java_17-25\.zip$/);
+  assert.match(byVersion['9.9.9-synthetic-nojava'].serverUrl, /Java_8\.zip$/);
+});
+
+test('normalizeIndex tolerates junk input', () => {
+  assert.deepEqual(gtnh.normalizeIndex(null), []);
+  assert.deepEqual(gtnh.normalizeIndex('nope'), []);
+});
+
+test('filterVersions hides betas unless asked', () => {
+  const entries = gtnh.normalizeIndex(raw);
+  assert.equal(
+    gtnh.filterVersions(entries, { includeBeta: false }).some((e) => e.channel === 'beta'),
+    false
+  );
+  assert.equal(gtnh.filterVersions(entries, { includeBeta: true }).length, entries.length);
+});
+
+test('pickLatest respects the channel filter', () => {
+  const entries = gtnh.normalizeIndex(raw);
+  assert.equal(gtnh.pickLatest(entries, { includeBeta: false }).version, '2.8.4');
+  assert.equal(gtnh.pickLatest(entries, { includeBeta: true }).version, '2.9.0-beta-2');
+  assert.equal(gtnh.pickLatest([], { includeBeta: true }), null);
+});

--- a/test/gtnhApi.test.js
+++ b/test/gtnhApi.test.js
@@ -4,7 +4,12 @@ require('./helpers/env');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const raw = require('./fixtures/gtnh-versions.json');
+const { migrate } = require('../src/db/migrate');
+const db = require('../src/db');
 const gtnh = require('../src/services/gtnhApi');
+
+// Initialize database for async tests
+migrate();
 
 test('normalizeIndex preserves the index order (newest first)', () => {
   const entries = gtnh.normalizeIndex(raw);
@@ -58,4 +63,188 @@ test('pickLatest respects the channel filter', () => {
   assert.equal(gtnh.pickLatest(entries, { includeBeta: false }).version, '2.8.4');
   assert.equal(gtnh.pickLatest(entries, { includeBeta: true }).version, '2.9.0-beta-2');
   assert.equal(gtnh.pickLatest([], { includeBeta: true }), null);
+});
+
+// ---- Async: fetchIndex + caching behavior ----------------------------------
+
+test('fresh cache is served without any fetch', async () => {
+  // Seed cache with recent timestamp
+  const now = new Date().toISOString().slice(0, 19);
+  db.run(
+    `INSERT INTO api_cache (key, value_json, fetched_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,
+    'gtnh:versions',
+    JSON.stringify(raw),
+    now
+  );
+
+  const originalFetch = globalThis.fetch;
+  const mockCalls = [];
+  globalThis.fetch = () => {
+    mockCalls.push(1);
+    throw new Error('fetch should not be called');
+  };
+  try {
+    const entries = await gtnh.listVersions();
+    assert.equal(entries.length, 5); // stable only
+    assert.equal(mockCalls.length, 0); // fetch was never called
+  } finally {
+    globalThis.fetch = originalFetch;
+    db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+  }
+});
+
+test('network failure serves the stale cache', async () => {
+  // Seed cache with old timestamp (older than 30-minute TTL)
+  const oldTime = new Date(Date.now() - 31 * 60 * 1000).toISOString().slice(0, 19);
+  db.run(
+    `INSERT INTO api_cache (key, value_json, fetched_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,
+    'gtnh:versions',
+    JSON.stringify(raw),
+    oldTime
+  );
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = () => {
+    fetchCalls++;
+    throw new Error('Network unreachable');
+  };
+  try {
+    const entries = await gtnh.listVersions();
+    assert.equal(entries.length, 5); // returns stale cache
+    assert.equal(fetchCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+  }
+});
+
+test('non-ok response serves the stale cache', async () => {
+  // Seed cache with old timestamp
+  const oldTime = new Date(Date.now() - 31 * 60 * 1000).toISOString().slice(0, 19);
+  db.run(
+    `INSERT INTO api_cache (key, value_json, fetched_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,
+    'gtnh:versions',
+    JSON.stringify(raw),
+    oldTime
+  );
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = () => {
+    fetchCalls++;
+    return { ok: false, status: 503 };
+  };
+  try {
+    const entries = await gtnh.listVersions();
+    assert.equal(entries.length, 5); // returns stale cache
+    assert.equal(fetchCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+  }
+});
+
+test('no cache and an unreachable index throws a 502', async () => {
+  db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = () => {
+    fetchCalls++;
+    throw new Error('Network error');
+  };
+  try {
+    await assert.rejects(
+      () => gtnh.listVersions(),
+      (err) => err.status === 502 && /Could not reach/.test(err.message)
+    );
+    assert.equal(fetchCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('getVersion throws 404 for a key not in the index', async () => {
+  const now = new Date().toISOString().slice(0, 19);
+  db.run(
+    `INSERT INTO api_cache (key, value_json, fetched_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,
+    'gtnh:versions',
+    JSON.stringify(raw),
+    now
+  );
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = () => {
+    fetchCalls++;
+    throw new Error('fetch should not be called');
+  };
+  try {
+    await assert.rejects(
+      () => gtnh.getVersion('99.99.99-nonexistent'),
+      (err) => err.status === 404 && /Unknown GTNH pack version/.test(err.message)
+    );
+    assert.equal(fetchCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+  }
+});
+
+test('a successful fetch writes the cache', async () => {
+  db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = () => {
+    fetchCalls++;
+    return {
+      ok: true,
+      json: async () => raw,
+    };
+  };
+  try {
+    const entries = await gtnh.listVersions();
+    assert.equal(entries.length, 5); // stable only
+    assert.equal(fetchCalls, 1);
+
+    // Verify cache was written
+    const cached = db.get('SELECT value_json FROM api_cache WHERE key = ?', 'gtnh:versions');
+    assert.ok(cached);
+    const cached_raw = JSON.parse(cached.value_json);
+    assert.deepEqual(Object.keys(cached_raw), Object.keys(raw));
+  } finally {
+    globalThis.fetch = originalFetch;
+    db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+  }
+});
+
+test('malformed JSON response serves stale cache or throws 502', async () => {
+  db.run('DELETE FROM api_cache WHERE key = ?', 'gtnh:versions');
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = () => {
+    fetchCalls++;
+    return {
+      ok: true,
+      json: async () => {
+        throw new Error('Unexpected token <');
+      },
+    };
+  };
+  try {
+    await assert.rejects(
+      () => gtnh.listVersions(),
+      (err) => err.status === 502 && /malformed JSON/.test(err.message)
+    );
+    assert.equal(fetchCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/test/javaMatrix.test.js
+++ b/test/javaMatrix.test.js
@@ -31,3 +31,25 @@ test('pickJavaTag maps MC versions to the right image tag', () => {
 test('pickJavaTag treats the 25.x/26.x era as latest', () => {
   assert.equal(pickJavaTag('26.2'), 'latest');
 });
+
+test('pickJavaTag picks the newest Java a GTNH pack version allows', () => {
+  assert.equal(pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: 25 }), 'java25');
+  assert.equal(pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: 21 }), 'java21');
+  // No java24/java20 image is published — ladder down to the next tag that exists.
+  assert.equal(pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: 24 }), 'java21');
+  assert.equal(pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: 20 }), 'java17');
+  // Ancient caps fall back to the legacy pack.
+  assert.equal(pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: 8 }), 'java8');
+});
+
+test('pickJavaTag defaults GTNH to java17 when the cap is unknown', () => {
+  // No pin yet, or the index was unreachable. Every indexed GTNH version
+  // supports at least Java 17, so this always boots.
+  assert.equal(pickJavaTag('1.7.10', 'GTNH'), 'java17');
+  assert.equal(pickJavaTag('1.7.10', 'GTNH', { maxJavaVersion: null }), 'java17');
+});
+
+test('pickJavaTag ignores maxJavaVersion for non-GTNH types', () => {
+  assert.equal(pickJavaTag('1.7.10', 'FORGE', { maxJavaVersion: 25 }), 'java8');
+  assert.equal(pickJavaTag('1.21.4', 'PAPER', { maxJavaVersion: 17 }), 'java21');
+});

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -6,6 +6,28 @@ const assert = require('node:assert/strict');
 const app = require('./helpers/app'); // migrates the DB + gives us seedServer()
 const db = require('../src/db');
 const packs = require('../src/services/packs');
+const gtnhApi = require('../src/services/gtnhApi');
+const rawIndex = require('./fixtures/gtnh-versions.json');
+
+/** Serve the fixture instead of the live index, for every gtnhApi network call. */
+function stubIndex() {
+  const entries = gtnhApi.normalizeIndex(rawIndex);
+  const realList = gtnhApi.listVersions;
+  const realGet = gtnhApi.getVersion;
+  const realLatest = gtnhApi.latest;
+  gtnhApi.listVersions = async ({ includeBeta = false } = {}) => gtnhApi.filterVersions(entries, { includeBeta });
+  gtnhApi.getVersion = async (v) => {
+    const found = entries.find((e) => e.version === v);
+    if (!found) throw Object.assign(new Error(`Unknown GTNH pack version: ${v}`), { status: 404 });
+    return found;
+  };
+  gtnhApi.latest = async ({ includeBeta = false } = {}) => gtnhApi.pickLatest(entries, { includeBeta });
+  return () => {
+    gtnhApi.listVersions = realList;
+    gtnhApi.getVersion = realGet;
+    gtnhApi.latest = realLatest;
+  };
+}
 
 test('applyPack stores the java cap and channel on the pin', async () => {
   const id = app.seedServer('srv_gtnhpin');
@@ -48,29 +70,6 @@ test('applyPack leaves the new columns null for other platforms', async () => {
   assert.equal(pin.channel, null);
 });
 
-const gtnhApi = require('../src/services/gtnhApi');
-const rawIndex = require('./fixtures/gtnh-versions.json');
-
-/** Serve the fixture instead of the live index, for every gtnhApi network call. */
-function stubIndex() {
-  const entries = gtnhApi.normalizeIndex(rawIndex);
-  const realList = gtnhApi.listVersions;
-  const realGet = gtnhApi.getVersion;
-  const realLatest = gtnhApi.latest;
-  gtnhApi.listVersions = async ({ includeBeta = false } = {}) => gtnhApi.filterVersions(entries, { includeBeta });
-  gtnhApi.getVersion = async (v) => {
-    const found = entries.find((e) => e.version === v);
-    if (!found) throw Object.assign(new Error(`Unknown GTNH pack version: ${v}`), { status: 404 });
-    return found;
-  };
-  gtnhApi.latest = async ({ includeBeta = false } = {}) => gtnhApi.pickLatest(entries, { includeBeta });
-  return () => {
-    gtnhApi.listVersions = realList;
-    gtnhApi.getVersion = realGet;
-    gtnhApi.latest = realLatest;
-  };
-}
-
 test('resolvePack("gtnh") defaults to the newest stable version', async () => {
   const restore = stubIndex();
   try {
@@ -112,6 +111,7 @@ test('resolvePack("gtnh") offers every version, tagged for the picker', async ()
     assert.equal(allVersions[0].type, 'beta');
     assert.equal(allVersions.find((v) => v.id === '2.8.4').type, 'release');
     assert.equal(allVersions.find((v) => v.id === '2.8.4').maxJavaVersion, 25);
+    assert.equal(allVersions.find((v) => v.id === '2.8.4').date, '2025/12/23');
   } finally {
     restore();
   }
@@ -143,6 +143,90 @@ test('applying GTNH over a CurseForge pin strips the stale CF_ vars', async () =
     assert.equal(env.CF_SLUG, undefined);
     assert.equal(env.GTNH_PACK_VERSION, '2.8.4');
     assert.equal(env.VIEW_DISTANCE, '10'); // unrelated user env survives
+  } finally {
+    restore();
+  }
+});
+
+test('applying a non-GTNH pack over a GTNH pin strips GTNH_PACK_VERSION and SKIP_GTNH_UPDATE_CHECK', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_swap2');
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', {});
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+    let env = JSON.parse(db.get('SELECT env_json FROM servers WHERE id = ?', id).env_json);
+    assert.equal(env.GTNH_PACK_VERSION, '2.8.4');
+    assert.equal(env.SKIP_GTNH_UPDATE_CHECK, 'true');
+    db.run(`UPDATE servers SET env_json = ? WHERE id = ?`, JSON.stringify({ ...env, VIEW_DISTANCE: '10' }), id);
+
+    // Hand-built descriptor, the way the Task 3 tests do — no stub needed for a non-GTNH platform.
+    await packs.applyPack(
+      id,
+      {
+        platform: 'modrinth',
+        projectRef: 'sop',
+        projectName: 'Simply Optimized',
+        versionId: 'abc123',
+        versionName: '1.0.0',
+        mcVersion: '1.21.1',
+      },
+      { actor: 'test', force: true }
+    );
+    env = JSON.parse(db.get('SELECT env_json FROM servers WHERE id = ?', id).env_json);
+    assert.equal(env.GTNH_PACK_VERSION, undefined);
+    assert.equal(env.SKIP_GTNH_UPDATE_CHECK, undefined);
+    assert.equal(env.VIEW_DISTANCE, '10'); // unrelated user env survives
+  } finally {
+    restore();
+  }
+});
+
+test('latestFor("gtnh") offers the newest stable to a server pinned on an older stable, never a newer beta', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_latest_stable');
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.7.4' });
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+    const info = await packs.latestFor(id);
+    assert.deepEqual(
+      Object.keys(info).sort(),
+      ['current', 'latest', 'platform', 'projectName', 'projectRef', 'updateAvailable'].sort()
+    );
+    assert.equal(info.current.id, '2.7.4');
+    assert.equal(info.latest.id, '2.8.4'); // newest stable, not the newer 2.9.0-beta-2
+    assert.equal(info.updateAvailable, true);
+    assert.equal(info.projectName, 'GT New Horizons');
+    assert.equal(info.projectRef, 'gtnh');
+    assert.equal(info.platform, 'gtnh');
+  } finally {
+    restore();
+  }
+});
+
+test('latestFor("gtnh") reports no update once already on the newest stable', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_latest_current');
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', {}); // newest stable: 2.8.4
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+    const info = await packs.latestFor(id);
+    assert.equal(info.current.id, '2.8.4');
+    assert.equal(info.latest.id, '2.8.4');
+    assert.equal(info.updateAvailable, false);
+  } finally {
+    restore();
+  }
+});
+
+test('latestFor("gtnh") tracks betas for a server pinned to a beta', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_latest_beta');
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.9.0-beta-2' });
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+    const info = await packs.latestFor(id);
+    assert.equal(info.current.id, '2.9.0-beta-2');
+    assert.equal(info.latest.id, '2.9.0-beta-2'); // the newest beta
   } finally {
     restore();
   }

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -47,3 +47,103 @@ test('applyPack leaves the new columns null for other platforms', async () => {
   assert.equal(pin.max_java_version, null);
   assert.equal(pin.channel, null);
 });
+
+const gtnhApi = require('../src/services/gtnhApi');
+const rawIndex = require('./fixtures/gtnh-versions.json');
+
+/** Serve the fixture instead of the live index, for every gtnhApi network call. */
+function stubIndex() {
+  const entries = gtnhApi.normalizeIndex(rawIndex);
+  const realList = gtnhApi.listVersions;
+  const realGet = gtnhApi.getVersion;
+  const realLatest = gtnhApi.latest;
+  gtnhApi.listVersions = async ({ includeBeta = false } = {}) => gtnhApi.filterVersions(entries, { includeBeta });
+  gtnhApi.getVersion = async (v) => {
+    const found = entries.find((e) => e.version === v);
+    if (!found) throw Object.assign(new Error(`Unknown GTNH pack version: ${v}`), { status: 404 });
+    return found;
+  };
+  gtnhApi.latest = async ({ includeBeta = false } = {}) => gtnhApi.pickLatest(entries, { includeBeta });
+  return () => {
+    gtnhApi.listVersions = realList;
+    gtnhApi.getVersion = realGet;
+    gtnhApi.latest = realLatest;
+  };
+}
+
+test('resolvePack("gtnh") defaults to the newest stable version', async () => {
+  const restore = stubIndex();
+  try {
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', {});
+    assert.equal(resolved.platform, 'gtnh');
+    assert.equal(resolved.projectRef, 'gtnh');
+    assert.equal(resolved.projectName, 'GT New Horizons');
+    assert.equal(resolved.versionId, '2.8.4');
+    assert.equal(resolved.versionName, '2.8.4');
+    assert.equal(resolved.mcVersion, '1.7.10');
+    assert.equal(resolved.maxJavaVersion, 25);
+    assert.equal(resolved.channel, 'stable');
+    assert.equal(resolved.javaTag, 'java25');
+  } finally {
+    restore();
+  }
+});
+
+test('resolvePack("gtnh") pins an explicit version and reports its own java tag', async () => {
+  const restore = stubIndex();
+  try {
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.7.4' });
+    assert.equal(resolved.versionId, '2.7.4');
+    assert.equal(resolved.maxJavaVersion, 21);
+    assert.equal(resolved.javaTag, 'java21');
+    const beta = await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.9.0-beta-2' });
+    assert.equal(beta.channel, 'beta');
+  } finally {
+    restore();
+  }
+});
+
+test('resolvePack("gtnh") offers every version, tagged for the picker', async () => {
+  const restore = stubIndex();
+  try {
+    const { allVersions } = await packs.resolvePack('gtnh', 'gtnh', {});
+    // Betas are included in the list — the wizard filters them client-side.
+    assert.equal(allVersions[0].id, '2.9.0-beta-2');
+    assert.equal(allVersions[0].type, 'beta');
+    assert.equal(allVersions.find((v) => v.id === '2.8.4').type, 'release');
+    assert.equal(allVersions.find((v) => v.id === '2.8.4').maxJavaVersion, 25);
+  } finally {
+    restore();
+  }
+});
+
+test('resolvePack("gtnh") rejects a version that is not in the index', async () => {
+  const restore = stubIndex();
+  try {
+    await assert.rejects(() => packs.resolvePack('gtnh', 'gtnh', { versionId: '../../etc/passwd' }), /Unknown GTNH/);
+    await assert.rejects(() => packs.resolvePack('gtnh', 'gtnh', { versionId: '1.2.3' }), /Unknown GTNH/);
+  } finally {
+    restore();
+  }
+});
+
+test('packEnv("gtnh") pins the version and disables the image update check', () => {
+  const env = packs.packEnv({ platform: 'gtnh', projectRef: 'gtnh', versionId: '2.8.4' });
+  assert.deepEqual(env, { TYPE: 'GTNH', GTNH_PACK_VERSION: '2.8.4', SKIP_GTNH_UPDATE_CHECK: 'true' });
+});
+
+test('applying GTNH over a CurseForge pin strips the stale CF_ vars', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_swap');
+    db.run(`UPDATE servers SET env_json = ? WHERE id = ?`, JSON.stringify({ CF_SLUG: 'old', VIEW_DISTANCE: '10' }), id);
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', {});
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+    const env = JSON.parse(db.get('SELECT env_json FROM servers WHERE id = ?', id).env_json);
+    assert.equal(env.CF_SLUG, undefined);
+    assert.equal(env.GTNH_PACK_VERSION, '2.8.4');
+    assert.equal(env.VIEW_DISTANCE, '10'); // unrelated user env survives
+  } finally {
+    restore();
+  }
+});

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -146,9 +146,9 @@ test('resolvePack("gtnh") rejects a version that is not in the index', async () 
   }
 });
 
-test('packEnv("gtnh") pins the version and disables the image update check', () => {
+test('packEnv("gtnh") pins the version and does NOT skip the image check (it is the installer)', () => {
   const env = packs.packEnv({ platform: 'gtnh', projectRef: 'gtnh', versionId: '2.8.4' });
-  assert.deepEqual(env, { TYPE: 'GTNH', GTNH_PACK_VERSION: '2.8.4', SKIP_GTNH_UPDATE_CHECK: 'true' });
+  assert.deepEqual(env, { TYPE: 'GTNH', GTNH_PACK_VERSION: '2.8.4' });
 });
 
 test('applying GTNH over a CurseForge pin strips the stale CF_ vars', async () => {
@@ -175,8 +175,13 @@ test('applying a non-GTNH pack over a GTNH pin strips GTNH_PACK_VERSION and SKIP
     await packs.applyPack(id, resolved, { actor: 'test', force: true });
     let env = JSON.parse(db.get('SELECT env_json FROM servers WHERE id = ?', id).env_json);
     assert.equal(env.GTNH_PACK_VERSION, '2.8.4');
-    assert.equal(env.SKIP_GTNH_UPDATE_CHECK, 'true');
-    db.run(`UPDATE servers SET env_json = ? WHERE id = ?`, JSON.stringify({ ...env, VIEW_DISTANCE: '10' }), id);
+    // Simulate a user having toggled the skip flag by hand: switching
+    // platforms must still strip it (SKIP_GTNH_ is in the strip prefixes).
+    db.run(
+      `UPDATE servers SET env_json = ? WHERE id = ?`,
+      JSON.stringify({ ...env, SKIP_GTNH_UPDATE_CHECK: 'true', VIEW_DISTANCE: '10' }),
+      id
+    );
 
     // Hand-built descriptor, the way the Task 3 tests do — no stub needed for a non-GTNH platform.
     await packs.applyPack(

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -209,7 +209,7 @@ test('latestFor("gtnh") offers the newest stable to a server pinned on an older 
     const info = await packs.latestFor(id);
     assert.deepEqual(
       Object.keys(info).sort(),
-      ['current', 'latest', 'platform', 'projectName', 'projectRef', 'updateAvailable'].sort()
+      ['changelogUrl', 'current', 'latest', 'platform', 'projectName', 'projectRef', 'updateAvailable'].sort()
     );
     assert.equal(info.current.id, '2.7.4');
     assert.equal(info.latest.id, '2.8.4'); // newest stable, not the newer 2.9.0-beta-2
@@ -217,6 +217,11 @@ test('latestFor("gtnh") offers the newest stable to a server pinned on an older 
     assert.equal(info.projectName, 'GT New Horizons');
     assert.equal(info.projectRef, 'gtnh');
     assert.equal(info.platform, 'gtnh');
+    // The per-version diff link from the index entry, not a generic "all files" page.
+    assert.equal(
+      info.changelogUrl,
+      'https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/master/releases/changelogs/changelog%20from%202.8.3%20to%202.8.4.md'
+    );
   } finally {
     restore();
   }

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -288,3 +288,37 @@ test('resolveImage still honors an explicit user override', () => {
   db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10', java_tag = 'java8' WHERE id = ?`, id);
   assert.match(serversService.resolveImage(serversService.getServer(id)), /:java8$/);
 });
+
+test('resolveImage uses javaTagHint only before a pin exists (first-create fast path)', () => {
+  const id = app.seedServer('srv_gtnhhint');
+  db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10' WHERE id = ?`, id);
+  const server = serversService.getServer(id);
+
+  // No pin yet: the hint (what from-pack already resolved) wins over the java17
+  // fallback — avoids pulling java17 and then immediately re-pulling java25.
+  assert.match(serversService.resolveImage(server, { javaTagHint: 'java25' }), /:java25$/);
+  // No hint given: unchanged fallback behavior.
+  assert.match(serversService.resolveImage(server), /:java17$/);
+});
+
+test('resolveImage ignores javaTagHint once a real pin exists', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_gtnhhint2');
+    db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10' WHERE id = ?`, id);
+    await packs.applyPack(id, await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.7.4' }), {
+      actor: 'test',
+      force: true,
+    });
+    // Pin caps at java21 — a stale/incorrect hint must not override the real pin.
+    assert.match(serversService.resolveImage(serversService.getServer(id), { javaTagHint: 'java25' }), /:java21$/);
+  } finally {
+    restore();
+  }
+});
+
+test('resolveImage ignores javaTagHint when the user set an explicit java_tag', () => {
+  const id = app.seedServer('srv_gtnhhint3');
+  db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10', java_tag = 'java8' WHERE id = ?`, id);
+  assert.match(serversService.resolveImage(serversService.getServer(id), { javaTagHint: 'java25' }), /:java8$/);
+});

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -162,6 +162,38 @@ test('applying GTNH over a CurseForge pin strips the stale CF_ vars', async () =
     assert.equal(env.CF_SLUG, undefined);
     assert.equal(env.GTNH_PACK_VERSION, '2.8.4');
     assert.equal(env.VIEW_DISTANCE, '10'); // unrelated user env survives
+    // The FML world-migration auto-confirm rides along on every GTNH apply.
+    assert.equal(env.JVM_DD_OPTS, 'fml.queryResult=confirm');
+  } finally {
+    restore();
+  }
+});
+
+test('applying GTNH merges fml.queryResult=confirm into a user-set JVM_DD_OPTS', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_ddopts');
+    db.run(`UPDATE servers SET env_json = ? WHERE id = ?`, JSON.stringify({ JVM_DD_OPTS: 'user.flag=1' }), id);
+    const resolved = await packs.resolvePack('gtnh', 'gtnh', {});
+    await packs.applyPack(id, resolved, { actor: 'test', force: true });
+    let env = JSON.parse(db.get('SELECT env_json FROM servers WHERE id = ?', id).env_json);
+    assert.equal(env.JVM_DD_OPTS, 'user.flag=1 fml.queryResult=confirm');
+
+    // Switching away takes back only the panel's token; user pairs survive.
+    await packs.applyPack(
+      id,
+      {
+        platform: 'modrinth',
+        projectRef: 'sop',
+        projectName: 'Simply Optimized',
+        versionId: 'abc123',
+        versionName: '1.0.0',
+        mcVersion: '1.21.1',
+      },
+      { actor: 'test', force: true }
+    );
+    env = JSON.parse(db.get('SELECT env_json FROM servers WHERE id = ?', id).env_json);
+    assert.equal(env.JVM_DD_OPTS, 'user.flag=1');
   } finally {
     restore();
   }

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -231,3 +231,36 @@ test('latestFor("gtnh") tracks betas for a server pinned to a beta', async () =>
     restore();
   }
 });
+
+const serversService = require('../src/services/servers');
+
+test('resolveImage uses the pinned pack java cap for GTNH servers', async () => {
+  const restore = stubIndex();
+  try {
+    const id = app.seedServer('srv_gtnhimg');
+    db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10' WHERE id = ?`, id);
+    await packs.applyPack(id, await packs.resolvePack('gtnh', 'gtnh', {}), { actor: 'test', force: true });
+    assert.match(serversService.resolveImage(serversService.getServer(id)), /:java25$/);
+
+    await packs.applyPack(id, await packs.resolvePack('gtnh', 'gtnh', { versionId: '2.7.4' }), {
+      actor: 'test',
+      force: true,
+    });
+    assert.match(serversService.resolveImage(serversService.getServer(id)), /:java21$/);
+  } finally {
+    restore();
+  }
+});
+
+test('resolveImage falls back to java17 for an unpinned GTNH server', () => {
+  const id = app.seedServer('srv_gtnhbare');
+  db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10' WHERE id = ?`, id);
+  // Hand-made GTNH servers from before the pack platform existed have no pin.
+  assert.match(serversService.resolveImage(serversService.getServer(id)), /:java17$/);
+});
+
+test('resolveImage still honors an explicit user override', () => {
+  const id = app.seedServer('srv_gtnhoverride');
+  db.run(`UPDATE servers SET type = 'GTNH', mc_version = '1.7.10', java_tag = 'java8' WHERE id = ?`, id);
+  assert.match(serversService.resolveImage(serversService.getServer(id)), /:java8$/);
+});

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const app = require('./helpers/app'); // migrates the DB + gives us seedServer()
+const db = require('../src/db');
+const packs = require('../src/services/packs');
+
+test('applyPack stores the java cap and channel on the pin', async () => {
+  const id = app.seedServer('srv_gtnhpin');
+  await packs.applyPack(
+    id,
+    {
+      platform: 'gtnh',
+      projectRef: 'gtnh',
+      projectName: 'GT New Horizons',
+      versionId: '2.8.4',
+      versionName: '2.8.4',
+      mcVersion: '1.7.10',
+      maxJavaVersion: 25,
+      channel: 'stable',
+    },
+    { actor: 'test', force: true }
+  );
+  const pin = db.get('SELECT * FROM server_packs WHERE server_id = ?', id);
+  assert.equal(pin.platform, 'gtnh');
+  assert.equal(pin.max_java_version, 25);
+  assert.equal(pin.channel, 'stable');
+});
+
+test('applyPack leaves the new columns null for other platforms', async () => {
+  const id = app.seedServer('srv_mrpin');
+  await packs.applyPack(
+    id,
+    {
+      platform: 'modrinth',
+      projectRef: 'sop',
+      projectName: 'Simply Optimized',
+      versionId: 'abc123',
+      versionName: '1.0.0',
+      mcVersion: '1.21.1',
+    },
+    { actor: 'test', force: true }
+  );
+  const pin = db.get('SELECT * FROM server_packs WHERE server_id = ?', id);
+  assert.equal(pin.max_java_version, null);
+  assert.equal(pin.channel, null);
+});

--- a/test/packs-gtnh.test.js
+++ b/test/packs-gtnh.test.js
@@ -88,6 +88,25 @@ test('resolvePack("gtnh") defaults to the newest stable version', async () => {
   }
 });
 
+test('resolvePack("gtnh") honours includeBeta when no explicit versionId is given', async () => {
+  const restore = stubIndex();
+  try {
+    // Default (includeBeta omitted → false): newest STABLE, matching the
+    // fixture's newest stable entry (2.8.4), never the newer 2.9.0-beta-2.
+    const stableDefault = await packs.resolvePack('gtnh', 'gtnh', {});
+    assert.equal(stableDefault.versionId, '2.8.4');
+    assert.equal(stableDefault.channel, 'stable');
+
+    // Regression coverage for the upgrade-button downgrade bug: a caller that
+    // knows the pin is beta-tracking must be able to ask for the newest beta.
+    const betaLatest = await packs.resolvePack('gtnh', 'gtnh', { includeBeta: true });
+    assert.equal(betaLatest.versionId, '2.9.0-beta-2');
+    assert.equal(betaLatest.channel, 'beta');
+  } finally {
+    restore();
+  }
+});
+
 test('resolvePack("gtnh") pins an explicit version and reports its own java tag', async () => {
   const restore = stubIndex();
   try {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -4,6 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const app = require('./helpers/app');
 const eventsService = require('../src/events');
+const db = require('../src/db');
 
 let cookie;
 
@@ -66,4 +67,28 @@ test('console-label (extracted to servers service) sanitizes and 404s unknown se
   const ok = await app.req('PUT', '/api/servers/srv_label01/console-label', { cookie, body: { label: 'A§dmin\n\tX' } });
   assert.equal(ok.status, 200);
   assert.equal(ok.json.label, 'AdminX'); // § byte + control chars stripped
+});
+
+test('the pack platform enum accepts gtnh', async () => {
+  // Seed the cached index so the resolver never reaches the network.
+  db.run(
+    `INSERT INTO api_cache (key, value_json, fetched_at) VALUES ('gtnh:versions', ?, datetime('now'))
+     ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, fetched_at = excluded.fetched_at`,
+    JSON.stringify(require('./fixtures/gtnh-versions.json'))
+  );
+
+  // A bad version is rejected by the resolver with 404, not by the enum with 400.
+  const res = await app.req('POST', '/api/packs/resolve', {
+    cookie,
+    body: { platform: 'gtnh', ref: 'gtnh', versionId: 'definitely-not-a-version' },
+  });
+  assert.equal(res.status, 404);
+});
+
+test('an unknown pack platform is still rejected', async () => {
+  const res = await app.req('POST', '/api/packs/resolve', {
+    cookie,
+    body: { platform: 'technic', ref: 'tekkit' },
+  });
+  assert.equal(res.status, 400);
 });

--- a/views/modpacks.hbs
+++ b/views/modpacks.hbs
@@ -31,7 +31,8 @@
     {{#each packServers}}
       <div class="card cursor-pointer p-4 transition hover:border-line-strong hover:shadow-raised" style="border-top: 3px solid {{accent}}"
            data-pack-card data-server-id="{{id}}" data-server-name="{{name}}"
-           data-pack-name="{{pack.name}}" data-current="{{pack.version}}" data-latest="{{pack.latest}}">
+           data-pack-name="{{pack.name}}" data-current="{{pack.version}}" data-latest="{{pack.latest}}"
+           {{#if pack.latestVersionId}}data-version-id="{{pack.latestVersionId}}"{{/if}}>
         <div class="flex items-center gap-3">
           <img src="{{iconSrc this.icon}}" alt="" class="size-10 shrink-0 rounded-md" onerror="this.src='/icons/servers/grass.png'">
           <div class="min-w-0 flex-1">

--- a/views/wizard.hbs
+++ b/views/wizard.hbs
@@ -99,13 +99,13 @@
     <h3 class="mb-1 font-semibold">Pick a modpack</h3>
     <p class="help mb-4">Search Modrinth or CurseForge. The pack decides the loader and Minecraft version, and the install is always pinned to the exact pack version you choose — restarts never silently upgrade.</p>
     {{! GTNH ships outside Modrinth/CurseForge — a fixed card, not a search result }}
-    <div class='mb-4 flex flex-wrap items-center gap-3 rounded-md border border-line p-3' id='wz-gtnh-card'>
-      <div class='min-w-0 flex-1'>
-        <div class='font-semibold'>GT New Horizons</div>
-        <div class='text-xs text-ink-faint'>Minecraft 1.7.10 expert pack — needs 6 GB+ RAM and 20 GB+ disk. Runs on modern
+    <div class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-line p-3" id="wz-gtnh-card">
+      <div class="min-w-0 flex-1">
+        <div class="font-semibold">GT New Horizons</div>
+        <div class="text-xs text-ink-faint">Minecraft 1.7.10 expert pack — needs 6 GB+ RAM and 20 GB+ disk. Runs on modern
           Java.</div>
       </div>
-      <button type='button' class='btn shrink-0' id='wz-gtnh-pick'>Set up</button>
+      <button type="button" class="btn shrink-0" id="wz-gtnh-pick">Set up</button>
     </div>
     <div class="flex flex-wrap items-center gap-2">
       <input class="input min-w-48 flex-1" id="wz-pack-q" placeholder="e.g. Simply Optimized, All the Mods…" autocomplete="off">
@@ -119,11 +119,11 @@
       <div class="flex items-center gap-3 rounded-md border border-grass-700 bg-grass-600/10 p-3" id="wz-pack-summary"></div>
       <div class="mt-3 grid items-end gap-4 sm:grid-cols-[1fr_auto]">
         <div>
-          <label class='label' for='wz-pack-version'>Pack version
-            <span class='text-xs font-normal text-ink-faint'>(always pinned)</span></label>
-          <select class='input' id='wz-pack-version' data-label='Pack version'></select>
-          <label class='mt-2 hidden items-center gap-2 text-xs text-ink-faint' id='wz-gtnh-beta-row'>
-            <input type='checkbox' id='wz-gtnh-beta' />
+          <label class="label" for="wz-pack-version">Pack version
+            <span class="text-xs font-normal text-ink-faint">(always pinned)</span></label>
+          <select class="input" id="wz-pack-version" data-label="Pack version"></select>
+          <label class="mt-2 hidden items-center gap-2 text-xs text-ink-faint" id="wz-gtnh-beta-row">
+            <input type="checkbox" id="wz-gtnh-beta" />
             include beta releases
           </label>
         </div>

--- a/views/wizard.hbs
+++ b/views/wizard.hbs
@@ -98,6 +98,15 @@
   <div class="card mb-4 hidden p-5" id="wz-modpack">
     <h3 class="mb-1 font-semibold">Pick a modpack</h3>
     <p class="help mb-4">Search Modrinth or CurseForge. The pack decides the loader and Minecraft version, and the install is always pinned to the exact pack version you choose — restarts never silently upgrade.</p>
+    {{! GTNH ships outside Modrinth/CurseForge — a fixed card, not a search result }}
+    <div class='mb-4 flex flex-wrap items-center gap-3 rounded-md border border-line p-3' id='wz-gtnh-card'>
+      <div class='min-w-0 flex-1'>
+        <div class='font-semibold'>GT New Horizons</div>
+        <div class='text-xs text-ink-faint'>Minecraft 1.7.10 expert pack — needs 6 GB+ RAM and 20 GB+ disk. Runs on modern
+          Java.</div>
+      </div>
+      <button type='button' class='btn shrink-0' id='wz-gtnh-pick'>Set up</button>
+    </div>
     <div class="flex flex-wrap items-center gap-2">
       <input class="input min-w-48 flex-1" id="wz-pack-q" placeholder="e.g. Simply Optimized, All the Mods…" autocomplete="off">
       <div class="seg" id="wz-pack-platforms" role="group" aria-label="Search platform">
@@ -110,8 +119,13 @@
       <div class="flex items-center gap-3 rounded-md border border-grass-700 bg-grass-600/10 p-3" id="wz-pack-summary"></div>
       <div class="mt-3 grid items-end gap-4 sm:grid-cols-[1fr_auto]">
         <div>
-          <label class="label" for="wz-pack-version">Pack version <span class="text-xs font-normal text-ink-faint">(always pinned)</span></label>
-          <select class="input" id="wz-pack-version" data-label="Pack version"></select>
+          <label class='label' for='wz-pack-version'>Pack version
+            <span class='text-xs font-normal text-ink-faint'>(always pinned)</span></label>
+          <select class='input' id='wz-pack-version' data-label='Pack version'></select>
+          <label class='mt-2 hidden items-center gap-2 text-xs text-ink-faint' id='wz-gtnh-beta-row'>
+            <input type='checkbox' id='wz-gtnh-beta' />
+            include beta releases
+          </label>
         </div>
         <button type="button" class="btn mb-0.5" id="wz-pack-details-btn">{{{icon 'book-open' 'size-4'}}} View details</button>
       </div>


### PR DESCRIPTION
## What this adds

GregTech: New Horizons becomes a first-class modpack platform, running on modern Java.

`GTNH` already existed as a value in the server-type dropdown, but nothing else in the panel knew about it. Three gaps followed from that:

1. **Java.** `pickJavaTag()` resolved GTNH's Minecraft `1.7.10` to `java8`, so running it on Java 25 — which GTNH 2.8.0+ supports and recommends via its bundled lwjgl3ify patches — meant hand-overriding the image tag in Advanced settings.
2. **Pinning.** None of the `GTNH_*` environment variables were catalogued, so `GTNH_PACK_VERSION` defaulted to `latest` and the image silently upgraded the pack on every restart — the one thing the "modpacks are always pinned" invariant exists to prevent.
3. **Discovery.** No path through the creation wizard produced a working GTNH server.

## Approach

GTNH is added as a fourth `platform` inside `services/packs.js`, alongside `curseforge`, `modrinth` and `ftb`, backed by a new `services/gtnhApi.js` client over GTNH's own release index (`downloads.gtnewhorizons.com/versions.json` — the same index the itzg image resolves against).

Because `resolvePack` → `packEnv` → `applyPack` → `latestFor` already dispatch on platform and `server_packs` already holds the pin, update checking, blueprint export/import and the mods overlay work by construction rather than by special-casing.

**Java is data, not a guess.** Each index entry carries `maxJavaVersion`, so the panel ladders down to the newest image tag that fits: 25 → `java25`, 24/21 → `java21`, 20 → `java17`. That cap is stored on the pin and read at `resolveImage()`, the single place the image tag is decided — so `servers.java_tag` keeps meaning "the user overrode auto", and changing the pinned version re-resolves Java automatically on the recreate that `applyPack` already flags.

**The wizard** gets a fixed GTNH card on the From-modpack tab (GTNH isn't searchable on Modrinth/CurseForge), driving the existing selection UI: version picker with stable-by-default and an opt-in beta toggle, a read-only Java line, and a resource floor that raises RAM to 6 GB and disk to 20 GB without lowering anything you've already set.

## Notable details

- `SKIP_GTNH_UPDATE_CHECK` is set by the panel: the image's own boot-time update check is redundant against a pinned version and would fight the panel for ownership of updates. It also joins the env-strip prefix list, so switching platforms leaves no stale keys behind.
- Migration `008` adds two nullable columns to `server_packs` (`max_java_version`, `channel`); both are NULL for the three existing platforms, which need no code changes.
- The pinned channel is recorded, so a stable-tracking server is never offered a beta — including on the Upgrade path, where the resolver now receives the pin's channel rather than defaulting to stable.
- GTNH pack installs get a 30-minute window before an upgrade is treated as failed (~1–2 GB server pack plus a first boot that builds a 1.7.10 world with several hundred mods); 20 minutes was for CurseForge/Modrinth and 10 for everything else.
- The changelog link comes from the index entry, giving a real per-version diff rather than an "all files" page.
- The download host returns HTTP 403 without a `User-Agent`, so that header is load-bearing and commented as such.

## Security

The index is remote content. The changelog URL is extracted from its HTML and accepted only if it parses as `https:` on a `github.com` host, then escaped at render. `GTNH_PACK_VERSION` reaches container env, so a version is accepted only when it is a key present in the fetched index — an unknown string is a 404, never passed through — with a shape regex as defence in depth.

## Testing

43 new tests (130 → 173), all passing on a clean clone with **no network and no Docker**: the index client is split into a thin HTTP layer plus a pure `normalizeIndex`, tests either seed the `api_cache` row or stub `fetch`/the client module and restore in `finally`, and a trimmed real `versions.json` is committed as a fixture.

Covered: index normalization and channel/cap/changelog parsing, TTL and stale-cache fallback, the Java ladder at every cap, pin persistence including the update path, resolver behaviour and env stripping, the never-offer-a-beta-to-a-stable-server rule, image resolution from the pin, the API platform enums, and the field catalog.

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test` and `npm run build` all pass.

## Not covered by tests

The wizard changes have no automated coverage — the repo has no browser test harness, and I didn't add one. The card, beta toggle, Java line and resource floor are verified by reading and by confirming the page renders; a click-through is worth doing before merge.
