### PR TITLE
Fix stuck "Finishing startup" status on Paper 26.2's /list phrasing

### DIFF
--- a/src/docker/containers.js
+++ b/src/docker/containers.js
@@ -172,13 +172,13 @@ async function removeContainer(serverId) {
 }
 
 /**
- * Run a command via docker exec and capture its raw output + the process's exit
- * code. A timeout guards against a hung exec (unresponsive/deadlocked JVM)
+ * Run a command via docker exec and capture its raw output (+ exit code on
+ * request). A timeout guards against a hung exec (unresponsive/deadlocked JVM)
  * leaving the hijacked stream + connection open forever — critical because
  * liveCache fires this on an interval and hung calls would otherwise stack
  * without bound.
  */
-async function execRaw(serverId, cmd, { timeoutMs = 15000 } = {}) {
+async function execRaw(serverId, cmd, { timeoutMs = 15000, wantExitCode = false } = {}) {
   const container = getContainer(serverId);
   const exec = await container.exec({ Cmd: cmd, AttachStdout: true, AttachStderr: true });
   const stream = await exec.start({});
@@ -207,8 +207,25 @@ async function execRaw(serverId, cmd, { timeoutMs = 15000 } = {}) {
     stream.on('end', () => finish(resolve, Buffer.concat(chunks).toString('utf8')));
     stream.on('error', (err) => finish(reject, err));
   });
-  const { ExitCode } = await exec.inspect();
-  return { stdout, exitCode: ExitCode };
+  // The inspect is a second daemon round trip, opted into by the one caller
+  // that reads the code — everyone else skips both its cost and its failure
+  // modes. It must never hang past the timeout contract above, and it must
+  // never fail a command whose output was already captured: the exit code is
+  // best-effort, and null means "unknown" (callers already treat non-zero and
+  // unknown the same, as "not a confirmed success").
+  let exitCode = null;
+  if (wantExitCode) {
+    try {
+      const inspected = await Promise.race([
+        exec.inspect(),
+        new Promise((resolve) => setTimeout(resolve, timeoutMs, null).unref?.()),
+      ]);
+      if (inspected && typeof inspected.ExitCode === 'number') exitCode = inspected.ExitCode;
+    } catch {
+      /* exit code stays unknown */
+    }
+  }
+  return { stdout, exitCode };
 }
 
 /** Run a command via docker exec and capture its output (used for rcon-cli). */
@@ -223,10 +240,12 @@ async function execCapture(serverId, cmd, opts = {}) {
  * command itself failed" (e.g. rcon-cli exits non-zero and prints a connection
  * error to stderr when RCON isn't listening yet — docker exec itself still
  * succeeds since the container process is running, so execCapture alone can't
- * distinguish that from a genuine, parseable response).
+ * distinguish that from a genuine, parseable response). The code is best-effort:
+ * `exitCode` is null when the daemon didn't answer the inspect in time, which
+ * callers must treat as "not a confirmed success", never as an error.
  */
 async function execCaptureChecked(serverId, cmd, opts = {}) {
-  return execRaw(serverId, cmd, opts);
+  return execRaw(serverId, cmd, { ...opts, wantExitCode: true });
 }
 
 /**

--- a/src/docker/containers.js
+++ b/src/docker/containers.js
@@ -172,16 +172,17 @@ async function removeContainer(serverId) {
 }
 
 /**
- * Run a command via docker exec and capture its output (used for rcon-cli).
- * A timeout guards against a hung exec (unresponsive/deadlocked JVM) leaving the
- * hijacked stream + connection open forever — critical because liveCache fires
- * this on an interval and hung calls would otherwise stack without bound.
+ * Run a command via docker exec and capture its raw output + the process's exit
+ * code. A timeout guards against a hung exec (unresponsive/deadlocked JVM)
+ * leaving the hijacked stream + connection open forever — critical because
+ * liveCache fires this on an interval and hung calls would otherwise stack
+ * without bound.
  */
-async function execCapture(serverId, cmd, { timeoutMs = 15000 } = {}) {
+async function execRaw(serverId, cmd, { timeoutMs = 15000 } = {}) {
   const container = getContainer(serverId);
   const exec = await container.exec({ Cmd: cmd, AttachStdout: true, AttachStderr: true });
   const stream = await exec.start({});
-  return new Promise((resolve, reject) => {
+  const stdout = await new Promise((resolve, reject) => {
     const chunks = [];
     // Demux the Docker stream framing (8-byte headers).
     const out = { write: (b) => chunks.push(b) };
@@ -206,6 +207,26 @@ async function execCapture(serverId, cmd, { timeoutMs = 15000 } = {}) {
     stream.on('end', () => finish(resolve, Buffer.concat(chunks).toString('utf8')));
     stream.on('error', (err) => finish(reject, err));
   });
+  const { ExitCode } = await exec.inspect();
+  return { stdout, exitCode: ExitCode };
+}
+
+/** Run a command via docker exec and capture its output (used for rcon-cli). */
+async function execCapture(serverId, cmd, opts = {}) {
+  const { stdout } = await execRaw(serverId, cmd, opts);
+  return stdout;
+}
+
+/**
+ * Like execCapture, but also resolves the command's exit code so callers can
+ * tell "ran successfully but printed something unexpected" apart from "the
+ * command itself failed" (e.g. rcon-cli exits non-zero and prints a connection
+ * error to stderr when RCON isn't listening yet — docker exec itself still
+ * succeeds since the container process is running, so execCapture alone can't
+ * distinguish that from a genuine, parseable response).
+ */
+async function execCaptureChecked(serverId, cmd, opts = {}) {
+  return execRaw(serverId, cmd, opts);
 }
 
 /**
@@ -282,4 +303,5 @@ module.exports = {
   removeDataDir,
   chownDataDir,
   execCapture,
+  execCaptureChecked,
 };

--- a/src/services/liveCache.js
+++ b/src/services/liveCache.js
@@ -10,6 +10,7 @@ const { statsStream, statsOnce } = require('../docker/stats');
 const { execCaptureChecked, inspectStatus } = require('../docker/containers');
 const { fetchLogs } = require('../docker/logs');
 const { parsePlayerList } = require('../utils/rconList');
+const { cleanText } = require('../utils/ansi');
 
 // Boot-phase detection: a modded first boot passes through many meaningful
 // states — surface them instead of a flat "starting/unhealthy". Ordered by
@@ -61,12 +62,18 @@ const entries = new Map(); // serverId -> {stats, players, uptimeStartedAt, stop
 let syncTimer = null;
 let syncing = false;
 
-const EMPTY = { stats: null, players: null, startedAt: null };
+const EMPTY = { stats: null, players: null, startedAt: null, phase: null, upConfirmed: false };
 
 function get(serverId) {
   const e = entries.get(serverId);
   if (!e) return EMPTY;
-  return { stats: e.stats || null, players: e.players || null, startedAt: e.startedAt || null, phase: e.phase || null };
+  return {
+    stats: e.stats || null,
+    players: e.players || null,
+    startedAt: e.startedAt || null,
+    phase: e.phase || null,
+    upConfirmed: e.upConfirmed || false,
+  };
 }
 
 function getAll() {
@@ -77,6 +84,7 @@ function getAll() {
       players: e.players || null,
       startedAt: e.startedAt || null,
       phase: e.phase || null,
+      upConfirmed: e.upConfirmed || false,
     };
   }
   return out;
@@ -84,7 +92,14 @@ function getAll() {
 
 async function attach(serverId) {
   if (entries.has(serverId)) return;
-  const entry = { stats: null, players: null, startedAt: null, stopStats: null, playerTimer: null };
+  const entry = {
+    stats: null,
+    players: null,
+    startedAt: null,
+    upConfirmed: false,
+    stopStats: null,
+    playerTimer: null,
+  };
   entries.set(serverId, entry);
 
   try {
@@ -107,8 +122,27 @@ async function attach(serverId) {
     if (playersInFlight) return; // don't stack calls if one is slow/hung
     playersInFlight = true;
     try {
+      // A missed 'start' Docker event (the events stream reconnects after
+      // drops — see watcher.js's retryLater()) can leave the DB status never
+      // leaving running/starting/unhealthy across a real container restart,
+      // so sync() never re-attaches and this stale latch would otherwise
+      // survive the restart. Only worth the extra inspect call in the exact
+      // state it can bite: latched "up" but never got a real player count.
+      if (entry.upConfirmed && !entry.players) {
+        try {
+          const info = await inspectStatus(serverId);
+          if (info.startedAt && info.startedAt !== entry.startedAt) {
+            entry.startedAt = info.startedAt;
+            entry.upConfirmed = false;
+            entry.phase = null; // let refreshPhase classify the new boot
+          }
+        } catch {
+          /* inspect failed — leave the latch as-is, retry next tick */
+        }
+      }
+
       const { stdout, exitCode } = await execCaptureChecked(serverId, ['rcon-cli', 'list']);
-      const out = require('../utils/ansi').cleanText(stdout); // rcon-cli colorizes
+      const out = cleanText(stdout); // rcon-cli colorizes
       const parsed = parsePlayerList(out);
       if (parsed) {
         entry.players = { ...parsed, at: Date.now() };

--- a/src/services/liveCache.js
+++ b/src/services/liveCache.js
@@ -90,6 +90,21 @@ function getAll() {
   return out;
 }
 
+/**
+ * The status-detail chip for a live entry, or null when there's nothing to
+ * show. One definition shared by the SSR view model and the live-poll JSON
+ * route, so the label a page renders on load can't drift from the one the
+ * poll swaps in. While the server hasn't answered rcon yet the boot phase
+ * wins; "Player count unavailable" is the latched "rcon answers but /list is
+ * unparseable" state; a parsed player list means neither applies.
+ */
+function statusDetail(live) {
+  if (live.players) return null;
+  if (live.phase) return live.phase.label;
+  if (live.upConfirmed) return 'Player count unavailable';
+  return null;
+}
+
 async function attach(serverId) {
   if (entries.has(serverId)) return;
   const entry = {
@@ -238,4 +253,4 @@ async function sampleOnce(serverId) {
   }
 }
 
-module.exports = { get, getAll, startLiveCache, sync, detach, sampleOnce };
+module.exports = { get, getAll, statusDetail, startLiveCache, sync, detach, sampleOnce };

--- a/src/services/liveCache.js
+++ b/src/services/liveCache.js
@@ -7,7 +7,7 @@
 
 const db = require('../db');
 const { statsStream, statsOnce } = require('../docker/stats');
-const { execCapture, inspectStatus } = require('../docker/containers');
+const { execCaptureChecked, inspectStatus } = require('../docker/containers');
 const { fetchLogs } = require('../docker/logs');
 const { parsePlayerList } = require('../utils/rconList');
 
@@ -107,17 +107,21 @@ async function attach(serverId) {
     if (playersInFlight) return; // don't stack calls if one is slow/hung
     playersInFlight = true;
     try {
-      const raw = await execCapture(serverId, ['rcon-cli', 'list']);
-      const out = require('../utils/ansi').cleanText(raw); // rcon-cli colorizes
+      const { stdout, exitCode } = await execCaptureChecked(serverId, ['rcon-cli', 'list']);
+      const out = require('../utils/ansi').cleanText(stdout); // rcon-cli colorizes
       const parsed = parsePlayerList(out);
       if (parsed) {
         entry.players = { ...parsed, at: Date.now() };
         entry.phase = null; // rcon answering = fully up, no boot phase
-      } else if (out) {
-        // rcon answered but the "/list" phrasing didn't match any known pattern.
-        // We can't parse player counts, but rcon answering at all means the
-        // server is fully up — stop deriving the boot-phase label from logs so
-        // the UI doesn't get stuck showing e.g. "Finishing startup" forever.
+      } else if (exitCode === 0 && out) {
+        // rcon-cli exited successfully — RCON is genuinely answering — but the
+        // "/list" phrasing didn't match any known pattern. We can't parse player
+        // counts, but a clean exit means the server is fully up — stop deriving
+        // the boot-phase label from logs so the UI doesn't get stuck showing
+        // e.g. "Finishing startup" forever. A non-zero exit (e.g. rcon-cli's own
+        // "connection refused" while RCON isn't listening yet, which docker exec
+        // itself treats as a normal successful command) must NOT hit this branch,
+        // or every server would latch "up" on its very first, pre-RCON poll.
         entry.upConfirmed = true;
         entry.phase = null;
       }

--- a/src/services/liveCache.js
+++ b/src/services/liveCache.js
@@ -109,7 +109,7 @@ async function attach(serverId) {
     try {
       const raw = await execCapture(serverId, ['rcon-cli', 'list']);
       const out = require('../utils/ansi').cleanText(raw); // rcon-cli colorizes
-      const m = /There are (\d+) of a max of (\d+) players online:?\s*(.*)/i.exec(out);
+      const m = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?\.?\s*(.*)/i.exec(out);
       if (m) {
         entry.players = {
           online: Number(m[1]),
@@ -123,6 +123,13 @@ async function attach(serverId) {
           at: Date.now(),
         };
         entry.phase = null; // rcon answering = fully up, no boot phase
+      } else if (out) {
+        // rcon answered but the "/list" phrasing didn't match any known pattern.
+        // We can't parse player counts, but rcon answering at all means the
+        // server is fully up — stop deriving the boot-phase label from logs so
+        // the UI doesn't get stuck showing e.g. "Finishing startup" forever.
+        entry.upConfirmed = true;
+        entry.phase = null;
       }
     } catch {
       /* rcon not up yet — keep last value */
@@ -135,7 +142,7 @@ async function attach(serverId) {
   // log tail and classify what the startup pipeline is doing right now.
   let phaseInFlight = false;
   const refreshPhase = async () => {
-    if (entry.players || phaseInFlight) return; // already up, or a probe is running
+    if (entry.players || entry.upConfirmed || phaseInFlight) return; // already up, or a probe is running
     phaseInFlight = true;
     try {
       const tail = await fetchLogs(serverId, { tail: 40 });

--- a/src/services/liveCache.js
+++ b/src/services/liveCache.js
@@ -133,26 +133,38 @@ async function attach(serverId) {
   }
 
   let playersInFlight = false;
+  let lastRestartCheckAt = 0;
   const refreshPlayers = async () => {
     if (playersInFlight) return; // don't stack calls if one is slow/hung
     playersInFlight = true;
     try {
-      // A missed 'start' Docker event (the events stream reconnects after
-      // drops — see watcher.js's retryLater()) can leave the DB status never
-      // leaving running/starting/unhealthy across a real container restart,
-      // so sync() never re-attaches and this stale latch would otherwise
-      // survive the restart. Only worth the extra inspect call in the exact
-      // state it can bite: latched "up" but never got a real player count.
-      if (entry.upConfirmed && !entry.players) {
+      // A container restart the cache didn't see must reset the latched state,
+      // or the old boot's player list / upConfirmed survive into the new boot
+      // as convincing-but-stale live data (verified live: a panel restart shows
+      // the previous list for the whole reboot and suppresses boot phases).
+      // sync() only detaches when the DB status leaves running/starting, and a
+      // restart's die→start usually completes inside one 10s sync interval, so
+      // the entry never detaches; a missed 'start' Docker event (the events
+      // stream reconnects after drops — see watcher.js's retryLater()) has the
+      // same effect. Compare Docker's own StartedAt whenever ANY latched state
+      // exists, throttled to once a minute to keep the extra inspect off the
+      // 20s hot path.
+      if ((entry.upConfirmed || entry.players) && Date.now() - lastRestartCheckAt > 60000) {
+        lastRestartCheckAt = Date.now();
         try {
           const info = await inspectStatus(serverId);
-          if (info.startedAt && info.startedAt !== entry.startedAt) {
+          if (info.startedAt && entry.startedAt && info.startedAt !== entry.startedAt) {
             entry.startedAt = info.startedAt;
+            entry.players = null; // the old boot's list is not this boot's
             entry.upConfirmed = false;
             entry.phase = null; // let refreshPhase classify the new boot
+          } else if (info.startedAt && !entry.startedAt) {
+            // attach() ran before the container was Running (startedAt null) —
+            // record the real boot time WITHOUT treating it as a restart.
+            entry.startedAt = info.startedAt;
           }
         } catch {
-          /* inspect failed — leave the latch as-is, retry next tick */
+          /* inspect failed — leave the latch as-is, retry next time */
         }
       }
 

--- a/src/services/liveCache.js
+++ b/src/services/liveCache.js
@@ -9,7 +9,7 @@ const db = require('../db');
 const { statsStream, statsOnce } = require('../docker/stats');
 const { execCapture, inspectStatus } = require('../docker/containers');
 const { fetchLogs } = require('../docker/logs');
-const { PLAYER_NAME_RE } = require('../utils/playerName');
+const { parsePlayerList } = require('../utils/rconList');
 
 // Boot-phase detection: a modded first boot passes through many meaningful
 // states — surface them instead of a flat "starting/unhealthy". Ordered by
@@ -109,19 +109,9 @@ async function attach(serverId) {
     try {
       const raw = await execCapture(serverId, ['rcon-cli', 'list']);
       const out = require('../utils/ansi').cleanText(raw); // rcon-cli colorizes
-      const m = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?\.?\s*(.*)/i.exec(out);
-      if (m) {
-        entry.players = {
-          online: Number(m[1]),
-          max: Number(m[2]),
-          names: m[3]
-            ? m[3]
-                .split(',')
-                .map((n) => n.trim())
-                .filter((n) => PLAYER_NAME_RE.test(n))
-            : [],
-          at: Date.now(),
-        };
+      const parsed = parsePlayerList(out);
+      if (parsed) {
+        entry.players = { ...parsed, at: Date.now() };
         entry.phase = null; // rcon answering = fully up, no boot phase
       } else if (out) {
         // rcon answered but the "/list" phrasing didn't match any known pattern.

--- a/src/services/players.js
+++ b/src/services/players.js
@@ -13,6 +13,7 @@ const { recordEvent } = require('../events');
 const { execCapture } = require('../docker/containers');
 const mojangProfiles = require('./mojangProfiles');
 const { PLAYER_NAME_RE, isBedrockName } = require('../utils/playerName');
+const { parsePlayerList } = require('../utils/rconList');
 
 // Only these fixed filenames are ever touched — no user input reaches a path.
 const FILES = new Set(['usercache.json', 'whitelist.json', 'ops.json', 'banned-players.json', 'banned-ips.json']);
@@ -123,14 +124,12 @@ async function listOnlineNames(serverId, { throwOnError = false } = {}) {
     // rcon-cli colorizes output — strip ANSI/§ codes before parsing, and only
     // accept strict Minecraft name shapes so escapes never become "players".
     const out = require('../utils/ansi').cleanText(await rcon(serverId, 'list'));
-    const m = /There are \d+ of a max of \d+ players online:?\s*(.*)/i.exec(out);
-    if (!m) return [];
-    return m[1]
-      ? m[1]
-          .split(',')
-          .map((n) => n.trim())
-          .filter((n) => PLAYER_NAME_RE.test(n))
-      : [];
+    const parsed = parsePlayerList(out);
+    // An unparseable response is NOT "confirmed nobody online" — callers like
+    // editContext rely on throwOnError to tell those apart before an offline
+    // .dat edit, where guessing wrong risks corrupting a live player's save.
+    if (!parsed) throw httpError(502, 'Could not parse player list from RCON output');
+    return parsed.names;
   } catch (err) {
     if (throwOnError) throw err;
     return [];

--- a/src/services/players.js
+++ b/src/services/players.js
@@ -14,6 +14,9 @@ const { execCapture } = require('../docker/containers');
 const mojangProfiles = require('./mojangProfiles');
 const { PLAYER_NAME_RE, isBedrockName } = require('../utils/playerName');
 const { parsePlayerList } = require('../utils/rconList');
+// Aliased: this file already has its own cleanText() below (strips control
+// chars from RCON-bound messages) — this one strips ANSI/§ colour codes.
+const { cleanText: cleanAnsiText } = require('../utils/ansi');
 
 // Only these fixed filenames are ever touched — no user input reaches a path.
 const FILES = new Set(['usercache.json', 'whitelist.json', 'ops.json', 'banned-players.json', 'banned-ips.json']);
@@ -97,7 +100,7 @@ async function rcon(serverId, ...args) {
 // Same, but strip the ANSI/§ colour codes rcon-cli injects — REQUIRED before
 // regex-parsing any rcon output (e.g. "\x1b[0m" otherwise becomes a stray "[0m").
 async function rconClean(serverId, ...args) {
-  return require('../utils/ansi').cleanText(await rcon(serverId, ...args));
+  return cleanAnsiText(await rcon(serverId, ...args));
 }
 
 // ANSI-clean rcon with an explicit timeout — /locate and spreadplayers can be slow
@@ -105,7 +108,7 @@ async function rconClean(serverId, ...args) {
 // stacking searches that freeze the server). Give teleport commands more room.
 async function rconT(serverId, timeoutMs, ...args) {
   const out = await execCapture(serverId, ['rcon-cli', '--', ...args.map(String)], { timeoutMs });
-  return require('../utils/ansi').cleanText(String(out || '').trim());
+  return cleanAnsiText(String(out || '').trim());
 }
 const TP_TIMEOUT_MS = 45000;
 
@@ -123,11 +126,10 @@ async function listOnlineNames(serverId, { throwOnError = false } = {}) {
   try {
     // rcon-cli colorizes output — strip ANSI/§ codes before parsing, and only
     // accept strict Minecraft name shapes so escapes never become "players".
-    const out = require('../utils/ansi').cleanText(await rcon(serverId, 'list'));
+    const out = cleanAnsiText(await rcon(serverId, 'list'));
     const parsed = parsePlayerList(out);
-    // An unparseable response is NOT "confirmed nobody online" — callers like
-    // editContext rely on throwOnError to tell those apart before an offline
-    // .dat edit, where guessing wrong risks corrupting a live player's save.
+    // Unparseable is "couldn't ask", not "confirmed nobody online" — see the
+    // throwOnError note above.
     if (!parsed) throw httpError(502, 'Could not parse player list from RCON output');
     return parsed.names;
   } catch (err) {
@@ -722,7 +724,7 @@ async function scanServerStructures(serverId, running) {
         let page = 1;
         let totalPages = 1;
         do {
-          const out = require('../utils/ansi').cleanText(
+          const out = cleanAnsiText(
             await execCapture(serverId, ['rcon-cli', prefix, 'tags', 'worldgen/structure', 'list', String(page)])
           );
           const pm = /<page (\d+) \/ (\d+)>/.exec(out);
@@ -878,7 +880,7 @@ async function fetchTagElements(serverId, prefix, tag) {
   let page = 1;
   let totalPages = 1;
   do {
-    const out = require('../utils/ansi').cleanText(
+    const out = cleanAnsiText(
       await execCapture(serverId, ['rcon-cli', prefix, 'tags', 'worldgen/biome', 'get', tag, String(page)])
     );
     const pm = /<page (\d+) \/ (\d+)>/.exec(out);

--- a/src/utils/rconList.js
+++ b/src/utils/rconList.js
@@ -1,11 +1,13 @@
 'use strict';
 
-// Parses `rcon-cli list` output. Paper 26.2 changed the phrasing from
-// "There are N of a max of M players online:" to
-// "There are N out of maximum M players online." — accept both, so the two
-// callers (liveCache boot-status polling, players.listOnlineNames) share one
-// regex instead of two copies that can silently drift apart, as happened
-// here. This only unifies the parsing: a null return still means "couldn't
+// Parses `rcon-cli list` output. Three phrasings are known:
+//   "There are N of a max of M players online:"   (modern vanilla/Paper)
+//   "There are N out of maximum M players online." (Paper 26.2)
+//   "There are N/M players online:"                (1.7.10-era Forge — every
+//                                                   GTNH server speaks this)
+// Accept all of them, so the two callers (liveCache boot-status polling,
+// players.listOnlineNames) share one regex instead of copies that can
+// silently drift apart, as happened here. This only unifies the parsing: a null return still means "couldn't
 // read player counts", and each caller decides for itself what that implies
 // (liveCache treats a successful-but-unparseable rcon reply as "server's up,
 // counts unknown"; listOnlineNames treats it as "couldn't ask" and, when
@@ -23,7 +25,8 @@ const { PLAYER_NAME_RE } = require('./playerName');
 // ambiguous (sentence period + Java "Steve", or no period + Bedrock
 // ".Steve") — we keep the Bedrock reading since not consuming the period is
 // the conservative parse.
-const LIST_RE = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?(?:\.(?=\s|$|\.))?\s*(.*)/i;
+const LIST_RE =
+  /There are (\d+)(?: (?:of a max of|out of maximum) |\/)(\d+) players online:?(?:\.(?=\s|$|\.))?\s*(.*)/i;
 
 /**
  * @param {string} text - ANSI/§-stripped `rcon-cli list` output.

--- a/src/utils/rconList.js
+++ b/src/utils/rconList.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Parses `rcon-cli list` output. Paper 26.2 changed the phrasing from
+// "There are N of a max of M players online:" to
+// "There are N out of maximum M players online." — accept both so the two
+// callers (liveCache boot-status polling, players.listOnlineNames) never
+// drift out of sync with each other again.
+
+const { PLAYER_NAME_RE } = require('./playerName');
+
+const LIST_RE = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?\.?\s*(.*)/i;
+
+/**
+ * @param {string} text - ANSI/§-stripped `rcon-cli list` output.
+ * @returns {{online: number, max: number, names: string[]} | null} null if the
+ *   text doesn't match any known phrasing (caller decides how to treat that).
+ */
+function parsePlayerList(text) {
+  const m = LIST_RE.exec(text);
+  if (!m) return null;
+  return {
+    online: Number(m[1]),
+    max: Number(m[2]),
+    names: m[3]
+      ? m[3]
+          .split(',')
+          .map((n) => n.trim())
+          .filter((n) => PLAYER_NAME_RE.test(n))
+      : [],
+  };
+}
+
+module.exports = { parsePlayerList };

--- a/src/utils/rconList.js
+++ b/src/utils/rconList.js
@@ -8,7 +8,11 @@
 
 const { PLAYER_NAME_RE } = require('./playerName');
 
-const LIST_RE = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?\.?\s*(.*)/i;
+// The trailing period only counts as punctuation when it's followed by
+// whitespace or end-of-string — otherwise a Bedrock name's leading "."
+// (e.g. ".Steve" landing right after the colon with no space) would get
+// eaten as the optional period instead of staying in the name capture.
+const LIST_RE = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?(?:\.(?=\s|$))?\s*(.*)/i;
 
 /**
  * @param {string} text - ANSI/§-stripped `rcon-cli list` output.

--- a/src/utils/rconList.js
+++ b/src/utils/rconList.js
@@ -14,10 +14,16 @@
 const { PLAYER_NAME_RE } = require('./playerName');
 
 // The trailing period only counts as punctuation when it's followed by
-// whitespace or end-of-string — otherwise a Bedrock name's leading "."
-// (e.g. ".Steve" landing right after the colon with no space) would get
-// eaten as the optional period instead of staying in the name capture.
-const LIST_RE = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?(?:\.(?=\s|$))?\s*(.*)/i;
+// whitespace, end-of-string, or another period — otherwise a Bedrock name's
+// leading "." (e.g. ".Steve" landing right after the colon with no space)
+// would get eaten as the optional period instead of staying in the name
+// capture. The extra-period case is the 26.2 mirror of that: "online..Steve"
+// is the sentence period plus Bedrock ".Steve", so the first "." is consumed
+// and the second stays with the name. A lone "online.Steve" is genuinely
+// ambiguous (sentence period + Java "Steve", or no period + Bedrock
+// ".Steve") — we keep the Bedrock reading since not consuming the period is
+// the conservative parse.
+const LIST_RE = /There are (\d+) (?:of a max of|out of maximum) (\d+) players online:?(?:\.(?=\s|$|\.))?\s*(.*)/i;
 
 /**
  * @param {string} text - ANSI/§-stripped `rcon-cli list` output.

--- a/src/utils/rconList.js
+++ b/src/utils/rconList.js
@@ -2,9 +2,14 @@
 
 // Parses `rcon-cli list` output. Paper 26.2 changed the phrasing from
 // "There are N of a max of M players online:" to
-// "There are N out of maximum M players online." — accept both so the two
-// callers (liveCache boot-status polling, players.listOnlineNames) never
-// drift out of sync with each other again.
+// "There are N out of maximum M players online." — accept both, so the two
+// callers (liveCache boot-status polling, players.listOnlineNames) share one
+// regex instead of two copies that can silently drift apart, as happened
+// here. This only unifies the parsing: a null return still means "couldn't
+// read player counts", and each caller decides for itself what that implies
+// (liveCache treats a successful-but-unparseable rcon reply as "server's up,
+// counts unknown"; listOnlineNames treats it as "couldn't ask" and, when
+// asked to, throws rather than guessing).
 
 const { PLAYER_NAME_RE } = require('./playerName');
 

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -262,11 +262,9 @@ router.get('/servers/live', (req, res) => {
       memUsedMb: e.stats ? Math.round(e.stats.memUsedBytes / 1024 / 1024) : null,
       players: e.players ? { online: e.players.online, max: e.players.max, names: e.players.names } : null,
       startedAt: e.startedAt || null,
-      // rcon answered with an unrecognized "/list" phrasing: up, but player
-      // counts are unavailable — distinct from "still booting" (e.phase set)
-      // and from "not classified yet" (both null), which look identical
-      // otherwise on the client hydration in public/js/app.js.
-      phase: e.phase ? e.phase.label : e.upConfirmed && !e.players ? 'Player count unavailable' : null,
+      // Shared with the SSR statusDetail (viewModels.js) so the label the page
+      // rendered on load and the one this poll hydrates in can never disagree.
+      phase: liveCache.statusDetail(e),
     };
   }
   res.json({ ok: true, servers: out });

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -262,7 +262,11 @@ router.get('/servers/live', (req, res) => {
       memUsedMb: e.stats ? Math.round(e.stats.memUsedBytes / 1024 / 1024) : null,
       players: e.players ? { online: e.players.online, max: e.players.max, names: e.players.names } : null,
       startedAt: e.startedAt || null,
-      phase: e.phase ? e.phase.label : null,
+      // rcon answered with an unrecognized "/list" phrasing: up, but player
+      // counts are unavailable — distinct from "still booting" (e.phase set)
+      // and from "not classified yet" (both null), which look identical
+      // otherwise on the client hydration in public/js/app.js.
+      phase: e.phase ? e.phase.label : e.upConfirmed && !e.players ? 'Player count unavailable' : null,
     };
   }
   res.json({ ok: true, servers: out });

--- a/src/web/viewModels.js
+++ b/src/web/viewModels.js
@@ -57,20 +57,19 @@ async function serverVM(s, { withLive = true } = {}) {
   if (withLive && (s.status === 'running' || s.status === 'starting' || s.status === 'unhealthy')) {
     // Never block a page render on Docker: everything comes from the in-memory
     // live cache (fed by streaming stats + periodic rcon list).
-    const live = require('../services/liveCache').get(s.id);
+    const liveCache = require('../services/liveCache');
+    const live = liveCache.get(s.id);
     if (live.stats) {
       vm.stats.cpuPct = live.stats.cpuPct;
       vm.stats.memUsedMb = Math.round(live.stats.memUsedBytes / 1024 / 1024);
     }
     if (live.startedAt) vm.stats.uptime = formatUptime(Date.now() - Date.parse(live.startedAt));
     if (live.players) vm.players = { ...vm.players, ...live.players };
-    // Boot-phase detail ("Downloading mods…", "Generating world") replaces the
-    // flat starting/unhealthy label while the server hasn't answered rcon yet.
-    if (live.phase && !live.players) vm.statusDetail = live.phase.label;
-    // rcon answered but /list didn't match a known phrasing — up, but we can't
-    // read player counts. Distinct from "still booting" (live.phase above) so
-    // that state isn't silently indistinguishable from "not classified yet".
-    else if (live.upConfirmed && !live.players) vm.statusDetail = 'Player count unavailable';
+    // Boot-phase detail ("Downloading mods…", "Generating world") or the
+    // latched "Player count unavailable" state — one shared derivation with
+    // the live-poll route, so the SSR chip and the hydrated one can't drift.
+    const detail = liveCache.statusDetail(live);
+    if (detail) vm.statusDetail = detail;
   }
   return vm;
 }

--- a/src/web/viewModels.js
+++ b/src/web/viewModels.js
@@ -67,6 +67,10 @@ async function serverVM(s, { withLive = true } = {}) {
     // Boot-phase detail ("Downloading mods…", "Generating world") replaces the
     // flat starting/unhealthy label while the server hasn't answered rcon yet.
     if (live.phase && !live.players) vm.statusDetail = live.phase.label;
+    // rcon answered but /list didn't match a known phrasing — up, but we can't
+    // read player counts. Distinct from "still booting" (live.phase above) so
+    // that state isn't silently indistinguishable from "not classified yet".
+    else if (live.upConfirmed && !live.players) vm.statusDetail = 'Player count unavailable';
   }
   return vm;
 }

--- a/test/rconList.test.js
+++ b/test/rconList.test.js
@@ -40,3 +40,8 @@ test('returns null for unrecognized output instead of guessing', () => {
   assert.equal(parsePlayerList('Unknown command'), null);
   assert.equal(parsePlayerList(''), null);
 });
+
+test('keeps a Bedrock name\'s leading "." when it lands right after the colon with no space', () => {
+  assert.deepEqual(parsePlayerList('There are 1 of a max of 20 players online:.Steve').names, ['.Steve']);
+  assert.deepEqual(parsePlayerList('There are 1 out of maximum 20 players online:.Steve').names, ['.Steve']);
+});

--- a/test/rconList.test.js
+++ b/test/rconList.test.js
@@ -51,3 +51,18 @@ test('keeps a Bedrock name glued to the 26.2 sentence period ("online..Steve")',
   // The sentence period before a space is still consumed as punctuation.
   assert.deepEqual(parsePlayerList('There are 1 out of maximum 20 players online. .Steve').names, ['.Steve']);
 });
+
+test('parses the 1.7.10-era Forge phrasing ("N/M") that every GTNH server speaks', () => {
+  // Verified against a live GTNH 2.7.4 server: `rcon-cli list` answers
+  // "There are 0/20 players online:".
+  assert.deepEqual(parsePlayerList('There are 0/20 players online:'), {
+    online: 0,
+    max: 20,
+    names: [],
+  });
+  assert.deepEqual(parsePlayerList('There are 2/20 players online: Steve, Alex'), {
+    online: 2,
+    max: 20,
+    names: ['Steve', 'Alex'],
+  });
+});

--- a/test/rconList.test.js
+++ b/test/rconList.test.js
@@ -45,3 +45,9 @@ test('keeps a Bedrock name\'s leading "." when it lands right after the colon wi
   assert.deepEqual(parsePlayerList('There are 1 of a max of 20 players online:.Steve').names, ['.Steve']);
   assert.deepEqual(parsePlayerList('There are 1 out of maximum 20 players online:.Steve').names, ['.Steve']);
 });
+
+test('keeps a Bedrock name glued to the 26.2 sentence period ("online..Steve")', () => {
+  assert.deepEqual(parsePlayerList('There are 1 out of maximum 20 players online..Steve').names, ['.Steve']);
+  // The sentence period before a space is still consumed as punctuation.
+  assert.deepEqual(parsePlayerList('There are 1 out of maximum 20 players online. .Steve').names, ['.Steve']);
+});

--- a/test/rconList.test.js
+++ b/test/rconList.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parsePlayerList } = require('../src/utils/rconList');
+
+test('parses the pre-26.2 phrasing ("of a max of")', () => {
+  assert.deepEqual(parsePlayerList('There are 0 of a max of 20 players online:'), {
+    online: 0,
+    max: 20,
+    names: [],
+  });
+  assert.deepEqual(parsePlayerList('There are 2 of a max of 20 players online: Steve, Alex'), {
+    online: 2,
+    max: 20,
+    names: ['Steve', 'Alex'],
+  });
+});
+
+test('parses the Paper 26.2 phrasing ("out of maximum")', () => {
+  assert.deepEqual(parsePlayerList('There are 0 out of maximum 20 players online.'), {
+    online: 0,
+    max: 20,
+    names: [],
+  });
+  assert.deepEqual(parsePlayerList('There are 2 out of maximum 20 players online. Steve, Alex'), {
+    online: 2,
+    max: 20,
+    names: ['Steve', 'Alex'],
+  });
+});
+
+test('filters out names that are not valid Minecraft usernames (e.g. stray ANSI/§ leftovers)', () => {
+  const parsed = parsePlayerList('There are 2 of a max of 20 players online: Steve, [0m');
+  assert.deepEqual(parsed.names, ['Steve']);
+});
+
+test('returns null for unrecognized output instead of guessing', () => {
+  assert.equal(parsePlayerList('Unknown command'), null);
+  assert.equal(parsePlayerList(''), null);
+});


### PR DESCRIPTION
## Summary

Paper 26.2 changed rcon-cli's `/list` response phrasing from `There are N of a max of M players online:` to `There are N out of maximum M players online.`. The boot-status regex in `liveCache.js` only matched the old phrasing, so `entry.players` stayed `null` forever and the server card kept showing the last boot-phase label (e.g. "Finishing startup") indefinitely, even after Docker reported the container healthy. Fixing that properly surfaced a chain of related issues, so this PR grew from a one-line regex fix into four commits:

1. **`9f2292a`** — Loosen the regex to accept both phrasings. Add a fallback: if `rcon-cli list` answers successfully but the output matches neither known pattern, mark the entry `upConfirmed` and stop re-deriving the boot-phase label from logs, instead of getting stuck forever. Doesn't fabricate player counts — they stay at their sane defaults until a future successful parse fills them in.
2. **`83cbb2b`** — `players.js` had its own, separate copy of the same `/list` regex that never got the 26.2 fix, and `listOnlineNames()` silently returned `[]` on unrecognized output even with `throwOnError: true`. That's used by `inventory.js`'s `editContext()` to decide whether it's safe to edit a player's `.dat` file directly on disk vs. going through RCON — on Paper 26.2 it could conclude an online player was offline and corrupt their live save. Extracted both regexes into a single shared `parsePlayerList()` util (`src/utils/rconList.js`), and an unparseable response is now treated as "unknown" (throws when `throwOnError` is set) instead of "confirmed nobody online".
3. **`9b9fe1f`** — The `upConfirmed` fallback from commit 1 had its own bug: `execCapture()` never checked the docker-exec exit code, so `rcon-cli`'s "connection refused" error (normal for the first several seconds of every boot, before RCON starts listening) was indistinguishable from a genuine-but-unparseable response. That meant `upConfirmed` would latch `true` on essentially the first poll of every server startup, permanently disabling boot-phase log classification for the rest of that boot — worse than the original bug. Added `execCaptureChecked()`, which also resolves the exec's exit code, and gated the latch on a clean (`0`) exit. Also fixed a regex edge case where a Bedrock player's leading `.` could get eaten if their name landed right after the colon with no space (`online:.Steve`).
4. **`52ab6d2`** — Follow-up hardening from a broader review pass:
   - Recover from a restart the Docker events stream missed (it does reconnect after drops, per `watcher.js`'s own `retryLater()`) by re-checking Docker's own `StartedAt` whenever the `upConfirmed` latch is stuck with no player counts, clearing it so boot-phase classification resumes for the new boot.
   - Expose `upConfirmed` through `get()`/`getAll()`/`/api/servers/live` so "confirmed up, player count unavailable" is no longer indistinguishable from "not classified yet" — surfaces as a "Player count unavailable" status-detail chip, reusing the existing boot-phase badge UI.
   - Minor cleanup: hoisted inline `require('../utils/ansi').cleanText(...)` calls to a top-level import (aliased `cleanAnsiText` in `players.js` to avoid colliding with that file's own unrelated local `cleanText(text, fallback)`), trimmed a duplicated rationale comment, and reworded `rconList.js`'s header comment so it doesn't overclaim what the shared parser unifies.

## Test plan
- [x] Full suite (`npm test`): 135/135 passing, including new `test/rconList.test.js` coverage for both `/list` phrasings, the Bedrock-name edge case, and the "unrecognized output" case.
- [x] Repro on a Paper 26.2 server (`VERSION: LATEST`): confirm the server card flips from "Finishing startup" to "Running" once Docker reports healthy, instead of staying stuck.
- [x] Confirm player count/online-names still populate correctly for both 26.1.2-style and 26.2-style `/list` output.
- [x] Confirm dashboard cards and the public status page don't regress (no `null`/`NaN` shown for player counts).
- [x] Confirm a Bedrock player (`.Name` / `*Name`) is still correctly recognized via `/list`, whitelist, and inventory edits.
- [x] Confirm an offline `.dat` edit on a Paper 26.2 server correctly refuses when it can't confirm the target player is offline (`inventory.js`'s `editContext`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)