### PR TITLE
Add TOTP two-factor authentication via authenticator apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "multer": "^1.4.5-lts.2",
         "nanoid": "^3.3.8",
         "prismarine-nbt": "^2.8.0",
+        "qrcode": "^1.5.4",
         "sanitize-html": "^2.14.0",
         "tar": "^7.4.3",
         "ws": "^8.18.1",
@@ -1646,6 +1647,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1988,6 +1998,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2035,6 +2054,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/docker-modem": {
       "version": "5.0.7",
@@ -4076,6 +4101,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4114,7 +4148,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4174,6 +4207,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -4335,6 +4377,197 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -4429,6 +4662,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4537,6 +4776,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -5139,6 +5384,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "multer": "^1.4.5-lts.2",
     "nanoid": "^3.3.8",
     "prismarine-nbt": "^2.8.0",
+    "qrcode": "^1.5.4",
     "sanitize-html": "^2.14.0",
     "tar": "^7.4.3",
     "ws": "^8.18.1",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -11,6 +11,7 @@ import './lib/tooltip.js';
 import './lib/dropdown.js';
 import './lib/taskTray.js';
 import './lib/seg.js';
+import './lib/twoFactor.js';
 
 // Expose for inline handlers and future page scripts.
 window.CD = { toast, openModal, confirmDialog, setBusy, withBusy };

--- a/public/js/lib/dropdown.js
+++ b/public/js/lib/dropdown.js
@@ -74,9 +74,14 @@ document.addEventListener('click', (e) => {
   }
   if (!openMenu) return;
   // A click on a menu item performs its action (delegated handlers still run —
-  // the event has already been dispatched) and the menu closes itself.
+  // the event has already been dispatched) and the menu closes itself. Deferred
+  // to the next tick: a menu item that's a submit button (e.g. Sign out) only
+  // fires its native form submission AFTER this click handler returns, so
+  // removing it from the DOM synchronously here (openMenu.remove(), inside
+  // close()) cancelled that submission outright — the button appeared to do
+  // nothing.
   if (openMenu.contains(e.target)) {
-    if (e.target.closest('[role="menuitem"]')) close();
+    if (e.target.closest('[role="menuitem"]')) setTimeout(close, 0);
     return;
   }
   close();

--- a/public/js/lib/twoFactor.js
+++ b/public/js/lib/twoFactor.js
@@ -49,7 +49,10 @@ async function openEnrollModal(trigger) {
           if (!res) return false;
           if (trigger) trigger.dataset.userTotpEnabled = '1';
           toast('Two-factor authentication is now enabled.');
-          showBackupCodes(res.backupCodes, 'Save your backup codes');
+          // Reload once they've saved their codes — the users table (Settings)
+          // and this dataset flag are both server-rendered/read at page-load,
+          // so a stale page would still show "off" until refreshed.
+          showBackupCodes(res.backupCodes, 'Save your backup codes', { reloadOnClose: true });
         },
       },
     ],
@@ -91,13 +94,14 @@ function openManageModal(trigger) {
           if (!res) return false;
           if (trigger) trigger.dataset.userTotpEnabled = '';
           toast('Two-factor authentication disabled.');
+          setTimeout(() => location.reload(), 600);
         },
       },
     ],
   });
 }
 
-function showBackupCodes(codes, title) {
+function showBackupCodes(codes, title, { reloadOnClose = false } = {}) {
   const content = document.createElement('div');
   content.className = 'space-y-3';
   const list = document.createElement('div');
@@ -120,7 +124,12 @@ function showBackupCodes(codes, title) {
   copyBtn.dataset.copy = codes.join('\n');
   content.append(list, warn, copyBtn);
 
-  openModal({ title, content, actions: [{ label: 'Done' }] });
+  openModal({
+    title,
+    content,
+    actions: [{ label: 'Done' }],
+    onClose: reloadOnClose ? () => location.reload() : undefined,
+  });
 }
 
 async function post(url, body) {

--- a/public/js/lib/twoFactor.js
+++ b/public/js/lib/twoFactor.js
@@ -32,6 +32,10 @@ async function openEnrollModal(trigger) {
     <div>
       <label class="label" for="tf-confirm-code">Enter the 6-digit code from your app</label>
       <input class="input font-mono text-center text-lg tracking-[0.3em]" id="tf-confirm-code" inputmode="numeric" maxlength="6" placeholder="000000">
+    </div>
+    <div>
+      <label class="label" for="tf-confirm-password">Confirm your password</label>
+      <input class="input" id="tf-confirm-password" type="password" autocomplete="current-password" placeholder="Your account password">
     </div>`;
 
   openModal({
@@ -45,7 +49,8 @@ async function openEnrollModal(trigger) {
         busyLabel: 'Verifying…',
         onClick: async () => {
           const code = content.querySelector('#tf-confirm-code').value.trim();
-          const res = await post('/api/account/totp/confirm', { secret: setup.secret, code });
+          const password = content.querySelector('#tf-confirm-password').value;
+          const res = await post('/api/account/totp/confirm', { secret: setup.secret, code, password });
           if (!res) return false;
           if (trigger) trigger.dataset.userTotpEnabled = '1';
           toast('Two-factor authentication is now enabled.');

--- a/public/js/lib/twoFactor.js
+++ b/public/js/lib/twoFactor.js
@@ -1,0 +1,143 @@
+// Self-service two-factor auth: the topbar user-menu "Two-factor
+// authentication" entry opens one of two flows — enroll (QR + confirm code +
+// one-time backup codes) or manage (regenerate codes / disable), both gated
+// by re-entering the current password on the server side.
+
+import { openModal } from './modal.js';
+import { toast } from './toast.js';
+
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('[data-open-2fa]')) return;
+  const trigger = document.querySelector('[data-menu="user-menu"]');
+  if (trigger?.dataset.userTotpEnabled === '1') openManageModal(trigger);
+  else openEnrollModal(trigger);
+});
+
+async function openEnrollModal(trigger) {
+  const setup = await post('/api/account/totp/setup', {});
+  if (!setup) return;
+
+  const content = document.createElement('div');
+  content.className = 'space-y-4';
+  content.innerHTML = `
+    <p class="text-sm text-ink-soft">Scan this with your authenticator app (Google Authenticator, Authy, 1Password, …), or enter the code manually.</p>
+    <div class="flex justify-center"><img src="${setup.qrDataUrl}" alt="2FA QR code" class="rounded-md border border-line" width="220" height="220"></div>
+    <div>
+      <label class="label">Manual entry code</label>
+      <div class="flex gap-2">
+        <input class="input flex-1 font-mono text-xs" id="tf-secret" value="${setup.secret}" readonly>
+        <button type="button" class="btn" data-copy="${setup.secret}">Copy</button>
+      </div>
+    </div>
+    <div>
+      <label class="label" for="tf-confirm-code">Enter the 6-digit code from your app</label>
+      <input class="input font-mono text-center text-lg tracking-[0.3em]" id="tf-confirm-code" inputmode="numeric" maxlength="6" placeholder="000000">
+    </div>`;
+
+  openModal({
+    title: 'Enable two-factor authentication',
+    content,
+    actions: [
+      { label: 'Cancel', kind: 'ghost' },
+      {
+        label: 'Enable',
+        kind: 'primary',
+        busyLabel: 'Verifying…',
+        onClick: async () => {
+          const code = content.querySelector('#tf-confirm-code').value.trim();
+          const res = await post('/api/account/totp/confirm', { secret: setup.secret, code });
+          if (!res) return false;
+          if (trigger) trigger.dataset.userTotpEnabled = '1';
+          toast('Two-factor authentication is now enabled.');
+          showBackupCodes(res.backupCodes, 'Save your backup codes');
+        },
+      },
+    ],
+  });
+}
+
+function openManageModal(trigger) {
+  const content = document.createElement('div');
+  content.className = 'space-y-4';
+  content.innerHTML = `
+    <p class="text-sm text-ink-soft">Two-factor authentication is enabled on your account. Confirm your password to regenerate backup codes or turn it off.</p>
+    <div>
+      <label class="label" for="tf-mgmt-password">Current password</label>
+      <input class="input" id="tf-mgmt-password" type="password" autocomplete="current-password">
+    </div>`;
+
+  openModal({
+    title: 'Two-factor authentication',
+    content,
+    actions: [
+      { label: 'Close', kind: 'ghost' },
+      {
+        label: 'Regenerate backup codes',
+        busyLabel: 'Regenerating…',
+        onClick: async () => {
+          const password = content.querySelector('#tf-mgmt-password').value;
+          const res = await post('/api/account/totp/backup-codes/regenerate', { password });
+          if (!res) return false;
+          showBackupCodes(res.backupCodes, 'New backup codes');
+        },
+      },
+      {
+        label: 'Disable 2FA',
+        kind: 'danger',
+        busyLabel: 'Disabling…',
+        onClick: async () => {
+          const password = content.querySelector('#tf-mgmt-password').value;
+          const res = await post('/api/account/totp/disable', { password });
+          if (!res) return false;
+          if (trigger) trigger.dataset.userTotpEnabled = '';
+          toast('Two-factor authentication disabled.');
+        },
+      },
+    ],
+  });
+}
+
+function showBackupCodes(codes, title) {
+  const content = document.createElement('div');
+  content.className = 'space-y-3';
+  const list = document.createElement('div');
+  list.className = 'grid grid-cols-2 gap-2 rounded-md bg-inset p-3 font-mono text-sm';
+  for (const code of codes) {
+    const span = document.createElement('span');
+    span.textContent = code;
+    list.appendChild(span);
+  }
+  const warn = document.createElement('p');
+  warn.className = 'text-xs text-ink-faint';
+  warn.textContent =
+    'Each code works once, to sign in if you lose access to your authenticator app. Save them somewhere safe — they will not be shown again.';
+  // Relies on app.js's global [data-copy] click handler rather than duplicating
+  // clipboard logic here.
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className = 'btn btn-sm';
+  copyBtn.textContent = 'Copy all';
+  copyBtn.dataset.copy = codes.join('\n');
+  content.append(list, warn, copyBtn);
+
+  openModal({ title, content, actions: [{ label: 'Done' }] });
+}
+
+async function post(url, body) {
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok || data.ok === false) {
+      toast(data.error || `Request failed (${res.status})`, { kind: 'error', timeout: 8000 });
+      return null;
+    }
+    return data;
+  } catch (err) {
+    toast(`Network error: ${err.message}`, { kind: 'error' });
+    return null;
+  }
+}

--- a/public/js/pages/settings.js
+++ b/public/js/pages/settings.js
@@ -114,8 +114,25 @@ function init() {
     const row = e.target.closest('[data-user-id]');
     if (!row) return;
     const delBtn = e.target.closest('[data-user-delete]');
+    const totpResetBtn = e.target.closest('[data-user-totp-reset]');
     if (e.target.closest('[data-user-password]')) {
       passwordModal(row.dataset.userId, row.dataset.username);
+    } else if (totpResetBtn) {
+      const ok = await confirmDialog({
+        title: `Reset 2FA for ${row.dataset.username}?`,
+        message:
+          'They will be signed out of any in-progress 2FA challenge and must set up a new authenticator next time they sign in.',
+        confirmLabel: 'Reset 2FA',
+        danger: true,
+      });
+      if (!ok) return;
+      await withBusy(totpResetBtn, async () => {
+        const res = await post(`/api/users/${row.dataset.userId}/totp/disable`, {});
+        if (res) {
+          toast('2FA reset.');
+          setTimeout(() => location.reload(), 600);
+        }
+      });
     } else if (delBtn) {
       const ok = await confirmDialog({
         title: `Delete user ${row.dataset.username}?`,

--- a/src/db/migrations/009_totp.js
+++ b/src/db/migrations/009_totp.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// Per-user TOTP two-factor auth. totp_secret is encrypted at rest (services/secrets.js,
+// same as RCON passwords and API keys) and only ever set once a confirmation code has
+// been verified — see services/totp.js. totp_backup_codes_json holds bcrypt hashes of
+// one-time recovery codes, never plaintext. totp_last_step guards against replaying a
+// captured code within its own 30s window.
+
+function up(db) {
+  db.exec(`
+    ALTER TABLE users ADD COLUMN totp_secret TEXT;
+    ALTER TABLE users ADD COLUMN totp_enabled INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE users ADD COLUMN totp_backup_codes_json TEXT;
+    ALTER TABLE users ADD COLUMN totp_last_step INTEGER;
+  `);
+}
+
+module.exports = { up };

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -101,17 +101,20 @@ function beginTotpEnrollment(id) {
   return { secret, otpauthUrl: totp.buildOtpauthUrl(secret, { account: user.username }) };
 }
 
-/** Verify the first live code, then persist the secret + fresh backup codes. */
-function confirmTotp(id, secret, code, { actor = 'system' } = {}) {
+/** Verify the account password + the first live code, then persist the secret + backup codes. */
+function confirmTotp(id, secret, code, password, { actor = 'system' } = {}) {
   const user = db.get('SELECT * FROM users WHERE id = ?', id);
   if (!user) throw httpError(404, 'User not found');
-  // A session with no password re-check could otherwise silently swap an
-  // already-configured secret out from under the account (the UI never offers
-  // this path, but the API must not rely on that) — require disableTotp's
-  // password check first, same as everywhere else 2FA state changes.
   if (user.totp_enabled) {
     throw httpError(409, 'Two-factor authentication is already enabled — disable it first to re-enroll.');
   }
+  // Re-check the account's own password before ENABLING 2FA, exactly as disable
+  // and regenerate do. Without it, a hijacked-but-unlocked session (no password
+  // needed) could enroll the attacker's OWN authenticator on an account with no
+  // 2FA yet — locking the real owner out on their next login until an admin
+  // force-reset. The UI always sends the password; the API must not rely on that.
+  // Checked before the code so it can't double as a code-verification oracle.
+  if (!bcrypt.compareSync(password, user.password_hash)) throw httpError(401, 'Wrong password');
   if (totp.verify(secret, code) == null) {
     throw httpError(400, 'That code is incorrect or expired — try the next one your app shows.');
   }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -7,6 +7,8 @@ const bcrypt = require('bcryptjs');
 const { nanoid } = require('nanoid');
 const db = require('../db');
 const { recordEvent } = require('../events');
+const totp = require('./totp');
+const secrets = require('./secrets');
 
 function firstRunNeeded() {
   return !db.get('SELECT 1 AS x FROM users LIMIT 1');
@@ -76,7 +78,141 @@ function deleteUser(id, { actor = 'system' } = {}) {
 }
 
 function publicUser(u) {
-  return { id: u.id, username: u.username, role: u.role, createdAt: u.created_at };
+  return {
+    id: u.id,
+    username: u.username,
+    role: u.role,
+    createdAt: u.created_at,
+    totpEnabled: Boolean(u.totp_enabled),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TOTP two-factor auth. Self-service (any role, acts on your own account) —
+// see web/routes/account.js — plus one admin recovery path in web/routes/api.js.
+// The secret is only ever written once a live code from it has been verified
+// (confirmTotp), so a setup a user never finishes leaves nothing persisted.
+
+/** Start enrollment: a fresh secret + otpauth URL, NOT persisted until confirmTotp(). */
+function beginTotpEnrollment(id) {
+  const user = db.get('SELECT username FROM users WHERE id = ?', id);
+  if (!user) throw httpError(404, 'User not found');
+  const secret = totp.generateSecret();
+  return { secret, otpauthUrl: totp.buildOtpauthUrl(secret, { account: user.username }) };
+}
+
+/** Verify the first live code, then persist the secret + fresh backup codes. */
+function confirmTotp(id, secret, code, { actor = 'system' } = {}) {
+  const user = db.get('SELECT * FROM users WHERE id = ?', id);
+  if (!user) throw httpError(404, 'User not found');
+  // A session with no password re-check could otherwise silently swap an
+  // already-configured secret out from under the account (the UI never offers
+  // this path, but the API must not rely on that) — require disableTotp's
+  // password check first, same as everywhere else 2FA state changes.
+  if (user.totp_enabled) {
+    throw httpError(409, 'Two-factor authentication is already enabled — disable it first to re-enroll.');
+  }
+  if (totp.verify(secret, code) == null) {
+    throw httpError(400, 'That code is incorrect or expired — try the next one your app shows.');
+  }
+  const backupCodes = totp.generateBackupCodes();
+  const hashed = backupCodes.map((c) => bcrypt.hashSync(c, 11));
+  // totp_last_step deliberately stays NULL here rather than recording this
+  // confirmation code's step: replay protection exists to stop a *login* code
+  // being reused, not to block the very first login from landing in the same
+  // 30s window as enrollment (a real code shown on-screen doesn't change until
+  // the window rolls over, so that first login legitimately reuses it).
+  db.run(
+    'UPDATE users SET totp_secret = ?, totp_enabled = 1, totp_backup_codes_json = ? WHERE id = ?',
+    secrets.encrypt(secret),
+    JSON.stringify(hashed),
+    id
+  );
+  recordEvent({ actor, type: 'user-2fa-enabled', summary: `Two-factor authentication enabled for ${user.username}` });
+  return { backupCodes };
+}
+
+/** Self-service disable — re-checks the account's own current password first. */
+function disableTotp(id, password, { actor = 'system' } = {}) {
+  const user = db.get('SELECT * FROM users WHERE id = ?', id);
+  if (!user) throw httpError(404, 'User not found');
+  if (!bcrypt.compareSync(password, user.password_hash)) throw httpError(401, 'Wrong password');
+  db.run(
+    'UPDATE users SET totp_secret = NULL, totp_enabled = 0, totp_backup_codes_json = NULL, totp_last_step = NULL WHERE id = ?',
+    id
+  );
+  recordEvent({
+    actor,
+    type: 'user-2fa-disabled',
+    summary: `Two-factor authentication disabled for ${user.username}`,
+  });
+}
+
+/** Admin recovery path: force-disable another user's 2FA (lost phone + backup codes). */
+function adminDisableTotp(id, { actor = 'system' } = {}) {
+  const user = db.get('SELECT username, totp_enabled FROM users WHERE id = ?', id);
+  if (!user) throw httpError(404, 'User not found');
+  if (!user.totp_enabled) return;
+  db.run(
+    'UPDATE users SET totp_secret = NULL, totp_enabled = 0, totp_backup_codes_json = NULL, totp_last_step = NULL WHERE id = ?',
+    id
+  );
+  recordEvent({
+    actor,
+    type: 'user-2fa-disabled',
+    summary: `Two-factor authentication reset for ${user.username} by an admin`,
+  });
+}
+
+/** Re-check the password, then reissue backup codes (old ones stop working). */
+function regenerateBackupCodes(id, password, { actor = 'system' } = {}) {
+  const user = db.get('SELECT * FROM users WHERE id = ?', id);
+  if (!user) throw httpError(404, 'User not found');
+  if (!user.totp_enabled) throw httpError(400, 'Two-factor authentication is not enabled');
+  if (!bcrypt.compareSync(password, user.password_hash)) throw httpError(401, 'Wrong password');
+  const backupCodes = totp.generateBackupCodes();
+  const hashed = backupCodes.map((c) => bcrypt.hashSync(c, 11));
+  db.run('UPDATE users SET totp_backup_codes_json = ? WHERE id = ?', JSON.stringify(hashed), id);
+  recordEvent({ actor, type: 'user-2fa-backup-codes', summary: `Backup codes regenerated for ${user.username}` });
+  return { backupCodes };
+}
+
+/**
+ * Verify a login-time TOTP or backup code for `id` (the pendingTotpUserId from
+ * the first login step). Returns true/false; never throws on a bad code (the
+ * route layer handles lockout/messaging same as a wrong password).
+ */
+function verifyTotpLogin(id, code) {
+  const user = db.get('SELECT * FROM users WHERE id = ? AND totp_enabled = 1', id);
+  if (!user || !user.totp_secret) return false;
+
+  const secret = secrets.tryDecrypt(user.totp_secret);
+  if (secret) {
+    const step = totp.verify(secret, code, { lastStep: user.totp_last_step });
+    if (step != null) {
+      db.run('UPDATE users SET totp_last_step = ? WHERE id = ?', step, id);
+      return true;
+    }
+  }
+
+  // Fall back to a backup code — single use, removed once matched.
+  let codes = [];
+  try {
+    codes = JSON.parse(user.totp_backup_codes_json || '[]');
+  } catch {
+    codes = [];
+  }
+  const cleanCode = String(code || '').trim();
+  const idx = codes.findIndex((hash) => bcrypt.compareSync(cleanCode, hash));
+  if (idx === -1) return false;
+  codes.splice(idx, 1);
+  db.run('UPDATE users SET totp_backup_codes_json = ? WHERE id = ?', JSON.stringify(codes), id);
+  recordEvent({
+    actor: user.username,
+    type: 'user-2fa-backup-used',
+    summary: `${user.username} signed in with a backup code (${codes.length} left)`,
+  });
+  return true;
 }
 
 /**
@@ -99,4 +235,10 @@ module.exports = {
   setRole,
   deleteUser,
   pruneExpiredSessions,
+  beginTotpEnrollment,
+  confirmTotp,
+  disableTotp,
+  adminDisableTotp,
+  regenerateBackupCodes,
+  verifyTotpLogin,
 };

--- a/src/services/totp.js
+++ b/src/services/totp.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// TOTP (RFC 6238) two-factor codes, hand-rolled on node:crypto rather than pulling in
+// a third-party auth library — the algorithm is small and well-specified (HMAC-SHA1
+// truncation over a 30s time step), and this is the security-critical half of 2FA, so
+// keeping it in a reviewable ~100 lines beats trusting an opaque dependency for it.
+// Secrets are base32 (RFC 4648) because that's what every authenticator app expects
+// pasted/scanned in.
+
+const crypto = require('node:crypto');
+
+const STEP_SECONDS = 30;
+const DIGITS = 6;
+const SECRET_BYTES = 20; // 160 bits, the RFC 6238 recommendation for HMAC-SHA1
+const BACKUP_CODE_COUNT = 10;
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+function base32Encode(buf) {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  return out;
+}
+
+function base32Decode(str) {
+  const clean = String(str || '')
+    .toUpperCase()
+    .replace(/[^A-Z2-7]/g, '');
+  let bits = 0;
+  let value = 0;
+  const bytes = [];
+  for (const ch of clean) {
+    const idx = BASE32_ALPHABET.indexOf(ch);
+    if (idx === -1) continue;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+/** A fresh random base32 secret, ready to embed in an otpauth:// URI. */
+function generateSecret() {
+  return base32Encode(crypto.randomBytes(SECRET_BYTES));
+}
+
+/** otpauth:// URI for QR/manual enrollment — issuer + account label, standard params. */
+function buildOtpauthUrl(secret, { issuer = 'Minecraft Server Manager', account }) {
+  const label = encodeURIComponent(`${issuer}:${account}`);
+  const params = new URLSearchParams({
+    secret,
+    issuer,
+    algorithm: 'SHA1',
+    digits: String(DIGITS),
+    period: String(STEP_SECONDS),
+  });
+  return `otpauth://totp/${label}?${params.toString()}`;
+}
+
+function hotp(secretBytes, counter) {
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+  const hmac = crypto.createHmac('sha1', secretBytes).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const bin =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return String(bin % 10 ** DIGITS).padStart(DIGITS, '0');
+}
+
+function currentStep(atMs = Date.now()) {
+  return Math.floor(atMs / 1000 / STEP_SECONDS);
+}
+
+/**
+ * Verify a 6-digit code against `secret` (base32), allowing ±1 step (30s) of clock
+ * drift. `lastStep` (if given) blocks replaying a code already accepted for that step
+ * or an earlier one — without it, a code intercepted once (shoulder-surf, log leak)
+ * stays valid for the rest of its 30s window even after legitimate use.
+ * Returns the matched step on success (persist as the new lastStep), or null.
+ */
+function verify(secret, code, { lastStep = null, window = 1, atMs = Date.now() } = {}) {
+  const cleanCode = String(code || '').replace(/\s+/g, '');
+  if (!/^\d{6}$/.test(cleanCode)) return null;
+  const secretBytes = base32Decode(secret);
+  if (!secretBytes.length) return null;
+  const step = currentStep(atMs);
+  for (let delta = -window; delta <= window; delta++) {
+    const candidateStep = step + delta;
+    if (lastStep != null && candidateStep <= lastStep) continue; // replay
+    const expected = hotp(secretBytes, candidateStep);
+    if (crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(cleanCode))) return candidateStep;
+  }
+  return null;
+}
+
+/** The current 6-digit code for `secret` — exported for tests; never used at runtime. */
+function codeAt(secret, atMs = Date.now()) {
+  return hotp(base32Decode(secret), currentStep(atMs));
+}
+
+/** `n` random backup codes, formatted xxxx-xxxx for readability. */
+function generateBackupCodes(n = BACKUP_CODE_COUNT) {
+  const codes = [];
+  for (let i = 0; i < n; i++) {
+    const raw = crypto.randomBytes(5).toString('hex'); // 10 hex chars
+    codes.push(`${raw.slice(0, 5)}-${raw.slice(5, 10)}`);
+  }
+  return codes;
+}
+
+module.exports = {
+  STEP_SECONDS,
+  generateSecret,
+  buildOtpauthUrl,
+  verify,
+  generateBackupCodes,
+  codeAt,
+  base32Encode, // exported for tests (RFC 6238's published vectors give a raw-byte secret, not base32)
+  base32Decode,
+};

--- a/src/services/totp.js
+++ b/src/services/totp.js
@@ -60,14 +60,21 @@ function generateSecret() {
 /** otpauth:// URI for QR/manual enrollment — issuer + account label, standard params. */
 function buildOtpauthUrl(secret, { issuer = 'Minecraft Server Manager', account }) {
   const label = encodeURIComponent(`${issuer}:${account}`);
-  const params = new URLSearchParams({
-    secret,
-    issuer,
-    algorithm: 'SHA1',
-    digits: String(DIGITS),
-    period: String(STEP_SECONDS),
-  });
-  return `otpauth://totp/${label}?${params.toString()}`;
+  // Build the query with encodeURIComponent, NOT URLSearchParams: the latter
+  // form-encodes a space as '+', but per RFC 3986 a '+' in a URI query is a
+  // literal plus, so apps that don't apply x-www-form-urlencoded decoding
+  // (Google Authenticator among them) show the issuer as "Minecraft+Server+
+  // Manager" and see it as conflicting with the %20-encoded label prefix.
+  const params = [
+    ['secret', secret],
+    ['issuer', issuer],
+    ['algorithm', 'SHA1'],
+    ['digits', String(DIGITS)],
+    ['period', String(STEP_SECONDS)],
+  ]
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join('&');
+  return `otpauth://totp/${label}?${params}`;
 }
 
 function hotp(secretBytes, counter) {
@@ -100,9 +107,16 @@ function verify(secret, code, { lastStep = null, window = 1, atMs = Date.now() }
   const secretBytes = base32Decode(secret);
   if (!secretBytes.length) return null;
   const step = currentStep(atMs);
+  // Ignore a stored lastStep that sits in the future beyond the drift window:
+  // that means the clock ran fast at last login and has since been corrected
+  // backward (NTP). Left active, every candidate in the current window is
+  // `<= lastStep` and gets skipped as a replay, locking the user out until wall
+  // time catches back up. It can only ever legitimately be within [step-window,
+  // step+window]; anything past that is stale, not a real prior use.
+  const replayFloor = lastStep != null && lastStep <= step + window ? lastStep : null;
   for (let delta = -window; delta <= window; delta++) {
     const candidateStep = step + delta;
-    if (lastStep != null && candidateStep <= lastStep) continue; // replay
+    if (replayFloor != null && candidateStep <= replayFloor) continue; // replay
     const expected = hotp(secretBytes, candidateStep);
     if (crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(cleanCode))) return candidateStep;
   }

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -184,6 +184,10 @@ function createApp() {
   app.use(require('./routes/auth'));
   app.use('/status', require('./routes/status')); // public, read-only, opt-in per server
   app.use(requireAuth);
+  // Account security (2FA) is self-service for every role, including viewer —
+  // mounted ahead of the viewer-read-only gate below since protecting your own
+  // account isn't a server-management action.
+  app.use('/api/account', require('./routes/account'));
   // Read-only roles (viewer) may never perform state changes. Admin-only areas
   // (users, storage, API keys, global files) add their own requireRole on top.
   app.use(requireWrite);

--- a/src/web/routes/account.js
+++ b/src/web/routes/account.js
@@ -14,23 +14,58 @@ const authService = require('../../services/auth');
 
 const router = express.Router();
 
+// /totp/setup mints a fresh secret and rasters a QR on every call, persisting
+// nothing — so throttle it per account. Without a cap, any authenticated session
+// (a read-only viewer included) could loop it to pin the event loop on a small
+// self-hosted box. A handful a minute is plenty for a real enrollment.
+const setupHits = new Map(); // userId -> timestamps (ms) within the window
+const SETUP_WINDOW_MS = 60_000;
+// Generous for a human fumbling enrollment (scan, cancel, switch app, retry),
+// but any per-minute cap defeats the event-loop DoS this guards against — a
+// tight abuse loop would need orders of magnitude more than this.
+const SETUP_MAX = 20;
+function throttleSetup(userId, nowMs) {
+  const recent = (setupHits.get(userId) || []).filter((t) => nowMs - t < SETUP_WINDOW_MS);
+  recent.push(nowMs);
+  setupHits.set(userId, recent);
+  return recent.length <= SETUP_MAX;
+}
+
 router.post(
   '/totp/setup',
   asyncHandler(async (req, res) => {
+    if (!throttleSetup(req.user.id, Date.now())) {
+      return res.status(429).json({ ok: false, error: 'Too many 2FA setup attempts — wait a minute and try again.' });
+    }
     const { secret, otpauthUrl } = authService.beginTotpEnrollment(req.user.id);
     const qrDataUrl = await QRCode.toDataURL(otpauthUrl, { margin: 1, width: 220 });
     res.json({ ok: true, secret, otpauthUrl, qrDataUrl });
   })
 );
 
+// Enabling 2FA re-checks the account password (confirmTotp), so it gets the same
+// shared login lockout as disable/regenerate below — a hijacked session can't use
+// the password-compare here as an unthrottled brute-force oracle.
 router.post(
   '/totp/confirm',
   asyncHandler((req, res) => {
-    const { secret, code } = z
-      .object({ secret: z.string().min(16).max(64), code: z.string().trim().min(1).max(16) })
+    const { secret, code, password } = z
+      .object({
+        secret: z.string().min(16).max(64),
+        code: z.string().trim().min(1).max(16),
+        password: z.string().min(1).max(200),
+      })
       .parse(req.body);
-    const { backupCodes } = authService.confirmTotp(req.user.id, secret, code, { actor: req.user.username });
-    res.json({ ok: true, backupCodes });
+    checkLoginAllowed(req.user.username, req.ip);
+    let result;
+    try {
+      result = authService.confirmTotp(req.user.id, secret, code, password, { actor: req.user.username });
+    } catch (err) {
+      if (err.status === 401) recordLoginFailure(req.user.username, req.ip);
+      throw err;
+    }
+    clearLoginFailures(req.user.username, req.ip);
+    res.json({ ok: true, backupCodes: result.backupCodes });
   })
 );
 

--- a/src/web/routes/account.js
+++ b/src/web/routes/account.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Self-service account security — two-factor auth. Mounted ahead of
+// requireWrite (see web/app.js) so every role, including viewer, can protect
+// their OWN account; nothing here ever reads or writes another user's row.
+
+const express = require('express');
+const QRCode = require('qrcode');
+const { z } = require('zod');
+const asyncHandler = require('../middleware/asyncHandler');
+const { makeJsonErrorHandler } = require('../middleware/jsonErrorHandler');
+const authService = require('../../services/auth');
+
+const router = express.Router();
+
+router.post(
+  '/totp/setup',
+  asyncHandler(async (req, res) => {
+    const { secret, otpauthUrl } = authService.beginTotpEnrollment(req.user.id);
+    const qrDataUrl = await QRCode.toDataURL(otpauthUrl, { margin: 1, width: 220 });
+    res.json({ ok: true, secret, otpauthUrl, qrDataUrl });
+  })
+);
+
+router.post(
+  '/totp/confirm',
+  asyncHandler((req, res) => {
+    const { secret, code } = z
+      .object({ secret: z.string().min(16).max(64), code: z.string().trim().min(1).max(16) })
+      .parse(req.body);
+    const { backupCodes } = authService.confirmTotp(req.user.id, secret, code, { actor: req.user.username });
+    res.json({ ok: true, backupCodes });
+  })
+);
+
+router.post(
+  '/totp/disable',
+  asyncHandler((req, res) => {
+    const { password } = z.object({ password: z.string().min(1).max(200) }).parse(req.body);
+    authService.disableTotp(req.user.id, password, { actor: req.user.username });
+    res.json({ ok: true });
+  })
+);
+
+router.post(
+  '/totp/backup-codes/regenerate',
+  asyncHandler((req, res) => {
+    const { password } = z.object({ password: z.string().min(1).max(200) }).parse(req.body);
+    const { backupCodes } = authService.regenerateBackupCodes(req.user.id, password, { actor: req.user.username });
+    res.json({ ok: true, backupCodes });
+  })
+);
+
+router.use(makeJsonErrorHandler('account'));
+
+module.exports = router;

--- a/src/web/routes/account.js
+++ b/src/web/routes/account.js
@@ -9,6 +9,7 @@ const QRCode = require('qrcode');
 const { z } = require('zod');
 const asyncHandler = require('../middleware/asyncHandler');
 const { makeJsonErrorHandler } = require('../middleware/jsonErrorHandler');
+const { checkLoginAllowed, recordLoginFailure, clearLoginFailures } = require('../middleware/auth');
 const authService = require('../../services/auth');
 
 const router = express.Router();
@@ -33,11 +34,23 @@ router.post(
   })
 );
 
+// Both routes below re-check the account's own password — same lockout the
+// login form gets, keyed on this account (not IP alone), so a hijacked
+// session can't use the password-compare here as an unthrottled oracle to
+// brute-force the real password (bcrypt's cost alone isn't a hard stop).
+
 router.post(
   '/totp/disable',
   asyncHandler((req, res) => {
     const { password } = z.object({ password: z.string().min(1).max(200) }).parse(req.body);
-    authService.disableTotp(req.user.id, password, { actor: req.user.username });
+    checkLoginAllowed(req.user.username, req.ip);
+    try {
+      authService.disableTotp(req.user.id, password, { actor: req.user.username });
+    } catch (err) {
+      if (err.status === 401) recordLoginFailure(req.user.username, req.ip);
+      throw err;
+    }
+    clearLoginFailures(req.user.username, req.ip);
     res.json({ ok: true });
   })
 );
@@ -46,8 +59,16 @@ router.post(
   '/totp/backup-codes/regenerate',
   asyncHandler((req, res) => {
     const { password } = z.object({ password: z.string().min(1).max(200) }).parse(req.body);
-    const { backupCodes } = authService.regenerateBackupCodes(req.user.id, password, { actor: req.user.username });
-    res.json({ ok: true, backupCodes });
+    checkLoginAllowed(req.user.username, req.ip);
+    let result;
+    try {
+      result = authService.regenerateBackupCodes(req.user.id, password, { actor: req.user.username });
+    } catch (err) {
+      if (err.status === 401) recordLoginFailure(req.user.username, req.ip);
+      throw err;
+    }
+    clearLoginFailures(req.user.username, req.ip);
+    res.json({ ok: true, backupCodes: result.backupCodes });
   })
 );
 

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -1408,6 +1408,18 @@ router.delete(
   })
 );
 
+// Recovery path when a user loses both their authenticator and their backup
+// codes — an admin can force-clear 2FA without knowing their password (same
+// trust level as the admin password-reset above). The user re-enrolls fresh.
+router.post(
+  '/users/:id/totp/disable',
+  requireRole('admin'),
+  asyncHandler((req, res, next) => {
+    authService.adminDisableTotp(req.params.id, { actor: req.user.username });
+    res.json({ ok: true });
+  })
+);
+
 // ---- Modrinth search (mods manager) ----
 const modrinth = require('../../services/modrinthApi');
 

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -1411,10 +1411,16 @@ router.delete(
 // Recovery path when a user loses both their authenticator and their backup
 // codes — an admin can force-clear 2FA without knowing their password (same
 // trust level as the admin password-reset above). The user re-enrolls fresh.
+// Deliberately refuses to target the caller's own account: that would be a
+// password-free way to strip your own 2FA that /api/account/totp/disable
+// (which does re-check the password) exists specifically to prevent.
 router.post(
   '/users/:id/totp/disable',
   requireRole('admin'),
   asyncHandler((req, res, next) => {
+    if (req.params.id === req.user.id) {
+      return res.status(400).json({ ok: false, error: 'Use your own account’s 2FA settings to disable it.' });
+    }
     authService.adminDisableTotp(req.params.id, { actor: req.user.username });
     res.json({ ok: true });
   })

--- a/src/web/routes/auth.js
+++ b/src/web/routes/auth.js
@@ -108,6 +108,13 @@ router.post('/setup', (req, res) => {
 router.get('/login', (req, res) => {
   if (authService.firstRunNeeded()) return res.redirect('/setup');
   if (req.session && req.session.userId) return res.redirect('/');
+  // A fresh visit to /login abandons any in-progress 2FA challenge rather than
+  // leaving it dangling — re-entering credentials should start clean.
+  if (req.session) {
+    delete req.session.pendingTotpUserId;
+    delete req.session.pendingTotpUsername;
+    delete req.session.pendingTotpNext;
+  }
   res.render('login', { title: 'Sign in', layout: 'bare', next: safeNext(req.query.next) });
 });
 
@@ -131,6 +138,17 @@ router.post('/login', (req, res) => {
         next: safeNext(next),
       });
     }
+    if (user.totpEnabled) {
+      // Password alone does not authenticate — session.userId stays unset, so
+      // requireAuth still treats this session as signed out. Deliberately does
+      // NOT clear the login-failure counter yet: it stays shared with the 2FA
+      // code step below, so a correct password can't be used to reset the
+      // lockout right before brute-forcing the 6-digit code.
+      req.session.pendingTotpUserId = user.id;
+      req.session.pendingTotpUsername = user.username;
+      req.session.pendingTotpNext = safeNext(next);
+      return res.redirect('/login/2fa');
+    }
     clearLoginFailures(username, req.ip);
     req.session.regenerate((err) => {
       if (err)
@@ -143,6 +161,46 @@ router.post('/login', (req, res) => {
     });
   } catch (err) {
     res.status(err.status || 400).render('login', { title: 'Sign in', layout: 'bare', error: firstIssue(err) });
+  }
+});
+
+router.get('/login/2fa', (req, res) => {
+  if (!req.session || !req.session.pendingTotpUserId) return res.redirect('/login');
+  res.render('login-2fa', { title: 'Verify it’s you', layout: 'bare' });
+});
+
+router.post('/login/2fa', (req, res) => {
+  const pendingId = req.session && req.session.pendingTotpUserId;
+  const pendingUsername = req.session && req.session.pendingTotpUsername;
+  if (!pendingId) return res.redirect('/login');
+  try {
+    const { code } = z.object({ code: z.string().trim().min(1).max(64) }).parse(req.body);
+    checkLoginAllowed(pendingUsername, req.ip);
+    const ok = authService.verifyTotpLogin(pendingId, code);
+    if (!ok) {
+      recordLoginFailure(pendingUsername, req.ip);
+      return res
+        .status(401)
+        .render('login-2fa', { title: 'Verify it’s you', layout: 'bare', error: 'Incorrect code.' });
+    }
+    clearLoginFailures(pendingUsername, req.ip);
+    const next = req.session.pendingTotpNext;
+    delete req.session.pendingTotpUserId;
+    delete req.session.pendingTotpUsername;
+    delete req.session.pendingTotpNext;
+    req.session.regenerate((err) => {
+      if (err)
+        return res
+          .status(500)
+          .render('login-2fa', { title: 'Verify it’s you', layout: 'bare', error: 'Session error — try again.' });
+      req.session.userId = pendingId;
+      recordEvent({ actor: pendingUsername, type: 'login', summary: `${pendingUsername} signed in (2FA)` });
+      res.redirect(safeNext(next) || '/');
+    });
+  } catch (err) {
+    res
+      .status(err.status || 400)
+      .render('login-2fa', { title: 'Verify it’s you', layout: 'bare', error: firstIssue(err) });
   }
 });
 

--- a/test/login-2fa.test.js
+++ b/test/login-2fa.test.js
@@ -16,14 +16,14 @@ test.after(async () => {
   await app.stop();
 });
 
-/** Enroll 2FA on the given (already-authenticated) account and return its secret + fresh cookie jar reference. */
-async function enroll(cookie) {
+/** Enroll 2FA on the given (already-authenticated) account and return its secret + backup codes. */
+async function enroll(cookie, password = 'supersecret123') {
   const setup = await app.req('POST', '/api/account/totp/setup', { cookie, body: {} });
   assert.equal(setup.status, 200);
   const code = totp.codeAt(setup.json.secret);
   const confirm = await app.req('POST', '/api/account/totp/confirm', {
     cookie,
-    body: { secret: setup.json.secret, code },
+    body: { secret: setup.json.secret, code, password },
   });
   assert.equal(confirm.status, 200);
   return { secret: setup.json.secret, backupCodes: confirm.json.backupCodes };
@@ -37,13 +37,32 @@ test('self-service setup/confirm rejects a wrong code and never persists the sec
 
   const bad = await app.req('POST', '/api/account/totp/confirm', {
     cookie: adminCookie,
-    body: { secret: setup.json.secret, code: '000000' },
+    body: { secret: setup.json.secret, code: '000000', password: 'supersecret123' },
   });
   assert.equal(bad.status, 400);
 
   // Never confirmed — logging in still needs only a password, no /login/2fa hop.
   const login = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
   assert.equal(login.status, 302);
+});
+
+test('enabling 2FA requires the account password (blocks a session-only enroll takeover)', async () => {
+  const setup = await app.req('POST', '/api/account/totp/setup', { cookie: adminCookie, body: {} });
+  assert.equal(setup.status, 200);
+  const code = totp.codeAt(setup.json.secret);
+  // Valid secret + valid code but WRONG password must not enable 2FA.
+  const wrong = await app.req('POST', '/api/account/totp/confirm', {
+    cookie: adminCookie,
+    body: { secret: setup.json.secret, code, password: 'not-the-password' },
+  });
+  assert.equal(wrong.status, 401);
+  // And the account is still 2FA-less: a password login fully authenticates
+  // (a protected route returns 200), rather than parking on a pending 2FA step.
+  const login = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
+  assert.equal(login.status, 302);
+  const cookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  const authed = await app.req('GET', '/api/servers/live', { cookie });
+  assert.equal(authed.status, 200);
 });
 
 test('enrolling forks the login flow onto /login/2fa, and a correct code completes it', async () => {
@@ -102,7 +121,7 @@ test('confirm refuses to silently replace an already-enabled secret', async () =
   const code = totp.codeAt(setup.json.secret);
   const confirm = await app.req('POST', '/api/account/totp/confirm', {
     cookie: adminCookie,
-    body: { secret: setup.json.secret, code },
+    body: { secret: setup.json.secret, code, password: 'supersecret123' },
   });
   assert.equal(confirm.status, 409);
 
@@ -147,7 +166,7 @@ test('a viewer (read-only role) can still manage their own 2FA', async () => {
   const code = totp.codeAt(setup.json.secret);
   const confirm = await app.req('POST', '/api/account/totp/confirm', {
     cookie: viewerCookie,
-    body: { secret: setup.json.secret, code },
+    body: { secret: setup.json.secret, code, password: 'viewerpass123' },
   });
   assert.equal(confirm.status, 200);
 });
@@ -160,7 +179,7 @@ test("an admin can force-reset another user's 2FA without their password", async
   const userId = create.json.user.id;
   const login = await app.req('POST', '/login', { body: { username: 'resetme', password: 'resetmepass123' } });
   const userCookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
-  await enroll(userCookie);
+  await enroll(userCookie, 'resetmepass123');
 
   // Non-admin cannot reset their own (or anyone's) 2FA through the admin route.
   const denied = await app.req('POST', `/api/users/${userId}/totp/disable`, { cookie: userCookie, body: {} });

--- a/test/login-2fa.test.js
+++ b/test/login-2fa.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const app = require('./helpers/app');
+const totp = require('../src/services/totp');
+
+let adminCookie;
+
+test.before(async () => {
+  await app.start();
+  adminCookie = await app.adminCookie();
+});
+test.after(async () => {
+  await app.stop();
+});
+
+/** Enroll 2FA on the given (already-authenticated) account and return its secret + fresh cookie jar reference. */
+async function enroll(cookie) {
+  const setup = await app.req('POST', '/api/account/totp/setup', { cookie, body: {} });
+  assert.equal(setup.status, 200);
+  const code = totp.codeAt(setup.json.secret);
+  const confirm = await app.req('POST', '/api/account/totp/confirm', {
+    cookie,
+    body: { secret: setup.json.secret, code },
+  });
+  assert.equal(confirm.status, 200);
+  return { secret: setup.json.secret, backupCodes: confirm.json.backupCodes };
+}
+
+test('self-service setup/confirm rejects a wrong code and never persists the secret', async () => {
+  const setup = await app.req('POST', '/api/account/totp/setup', { cookie: adminCookie, body: {} });
+  assert.equal(setup.status, 200);
+  assert.match(setup.json.otpauthUrl, /^otpauth:\/\/totp\//);
+  assert.ok(setup.json.qrDataUrl.startsWith('data:image/'));
+
+  const bad = await app.req('POST', '/api/account/totp/confirm', {
+    cookie: adminCookie,
+    body: { secret: setup.json.secret, code: '000000' },
+  });
+  assert.equal(bad.status, 400);
+
+  // Never confirmed — logging in still needs only a password, no /login/2fa hop.
+  const login = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
+  assert.equal(login.status, 302);
+});
+
+test('enrolling forks the login flow onto /login/2fa, and a correct code completes it', async () => {
+  const { secret } = await enroll(adminCookie);
+
+  const login = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
+  assert.equal(login.status, 302);
+  const pendingCookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  assert.ok(pendingCookie, 'expected a session cookie to carry the pending 2FA state');
+
+  // The half-authenticated session must not pass requireAuth yet.
+  const blocked = await app.req('GET', '/api/servers/live', { cookie: pendingCookie });
+  assert.equal(blocked.status, 401);
+
+  const wrongCode = await app.req('POST', '/login/2fa', { cookie: pendingCookie, body: { code: '000000' } });
+  assert.equal(wrongCode.status, 401);
+
+  const code = totp.codeAt(secret);
+  const ok = await app.req('POST', '/login/2fa', { cookie: pendingCookie, body: { code } });
+  assert.equal(ok.status, 302);
+  const fullCookie = (ok.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  const authed = await app.req('GET', '/api/servers/live', { cookie: fullCookie });
+  assert.equal(authed.status, 200);
+
+  // Clean up — disable so later tests in this file start from a known state.
+  await app.req('POST', '/api/account/totp/disable', { cookie: fullCookie, body: { password: 'supersecret123' } });
+});
+
+test('a backup code completes login and is single-use', async () => {
+  const { backupCodes } = await enroll(adminCookie);
+  const code = backupCodes[0];
+
+  const login = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
+  const pendingCookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+
+  const first = await app.req('POST', '/login/2fa', { cookie: pendingCookie, body: { code } });
+  assert.equal(first.status, 302);
+  const fullCookie = (first.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+
+  // Reused backup code must fail on a second login attempt.
+  const login2 = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
+  const pendingCookie2 = (login2.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  const replay = await app.req('POST', '/login/2fa', { cookie: pendingCookie2, body: { code } });
+  assert.equal(replay.status, 401);
+
+  await app.req('POST', '/api/account/totp/disable', { cookie: fullCookie, body: { password: 'supersecret123' } });
+});
+
+test('confirm refuses to silently replace an already-enabled secret', async () => {
+  const { secret: originalSecret } = await enroll(adminCookie);
+
+  // Even a valid setup+code for a NEW secret must not overwrite the live one
+  // without disabling first — this is the path a hijacked session (no
+  // password) could otherwise use to take over 2FA undetected.
+  const setup = await app.req('POST', '/api/account/totp/setup', { cookie: adminCookie, body: {} });
+  const code = totp.codeAt(setup.json.secret);
+  const confirm = await app.req('POST', '/api/account/totp/confirm', {
+    cookie: adminCookie,
+    body: { secret: setup.json.secret, code },
+  });
+  assert.equal(confirm.status, 409);
+
+  // The original secret must still be the one that logs in.
+  const login = await app.req('POST', '/login', { body: { username: 'admin', password: 'supersecret123' } });
+  const pendingCookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  const ok = await app.req('POST', '/login/2fa', {
+    cookie: pendingCookie,
+    body: { code: totp.codeAt(originalSecret) },
+  });
+  assert.equal(ok.status, 302);
+  const fullCookie = (ok.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  await app.req('POST', '/api/account/totp/disable', { cookie: fullCookie, body: { password: 'supersecret123' } });
+});
+
+test('disable requires the current password', async () => {
+  await enroll(adminCookie);
+  const wrongPassword = await app.req('POST', '/api/account/totp/disable', {
+    cookie: adminCookie,
+    body: { password: 'not-the-password' },
+  });
+  assert.equal(wrongPassword.status, 401);
+
+  const ok = await app.req('POST', '/api/account/totp/disable', {
+    cookie: adminCookie,
+    body: { password: 'supersecret123' },
+  });
+  assert.equal(ok.status, 200);
+});
+
+test('a viewer (read-only role) can still manage their own 2FA', async () => {
+  const create = await app.req('POST', '/api/users', {
+    cookie: adminCookie,
+    body: { username: 'viewer2fa', password: 'viewerpass123', role: 'viewer' },
+  });
+  assert.equal(create.status, 201);
+  const login = await app.req('POST', '/login', { body: { username: 'viewer2fa', password: 'viewerpass123' } });
+  const viewerCookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+
+  const setup = await app.req('POST', '/api/account/totp/setup', { cookie: viewerCookie, body: {} });
+  assert.equal(setup.status, 200);
+  const code = totp.codeAt(setup.json.secret);
+  const confirm = await app.req('POST', '/api/account/totp/confirm', {
+    cookie: viewerCookie,
+    body: { secret: setup.json.secret, code },
+  });
+  assert.equal(confirm.status, 200);
+});
+
+test("an admin can force-reset another user's 2FA without their password", async () => {
+  const create = await app.req('POST', '/api/users', {
+    cookie: adminCookie,
+    body: { username: 'resetme', password: 'resetmepass123', role: 'operator' },
+  });
+  const userId = create.json.user.id;
+  const login = await app.req('POST', '/login', { body: { username: 'resetme', password: 'resetmepass123' } });
+  const userCookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  await enroll(userCookie);
+
+  // Non-admin cannot reset their own (or anyone's) 2FA through the admin route.
+  const denied = await app.req('POST', `/api/users/${userId}/totp/disable`, { cookie: userCookie, body: {} });
+  assert.equal(denied.status, 403);
+
+  const reset = await app.req('POST', `/api/users/${userId}/totp/disable`, { cookie: adminCookie, body: {} });
+  assert.equal(reset.status, 200);
+
+  // 2FA is off again — a plain password login now succeeds without a /login/2fa hop.
+  const relogin = await app.req('POST', '/login', { body: { username: 'resetme', password: 'resetmepass123' } });
+  assert.equal(relogin.status, 302);
+  const cookie2 = (relogin.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  const authed = await app.req('GET', '/api/servers/live', { cookie: cookie2 });
+  assert.equal(authed.status, 200);
+});

--- a/test/login-2fa.test.js
+++ b/test/login-2fa.test.js
@@ -176,3 +176,35 @@ test("an admin can force-reset another user's 2FA without their password", async
   const authed = await app.req('GET', '/api/servers/live', { cookie: cookie2 });
   assert.equal(authed.status, 200);
 });
+
+test('an admin cannot use the force-reset route on their own account (no password-free self-disable)', async () => {
+  const users = await app.req('GET', '/api/users', { cookie: adminCookie });
+  const adminId = users.json.users.find((u) => u.username === 'admin').id;
+  await enroll(adminCookie);
+
+  const selfReset = await app.req('POST', `/api/users/${adminId}/totp/disable`, { cookie: adminCookie, body: {} });
+  assert.equal(selfReset.status, 400);
+
+  // Still enabled — must go through the password-gated self-service path instead.
+  const stillOn = await app.req('POST', '/api/account/totp/disable', {
+    cookie: adminCookie,
+    body: { password: 'wrong' },
+  });
+  assert.equal(stillOn.status, 401);
+  await app.req('POST', '/api/account/totp/disable', { cookie: adminCookie, body: { password: 'supersecret123' } });
+});
+
+test('repeated wrong passwords against the self-service disable route get locked out', async () => {
+  await enroll(adminCookie);
+  let last;
+  for (let i = 0; i < 9; i++) {
+    last = await app.req('POST', '/api/account/totp/disable', { cookie: adminCookie, body: { password: 'wrong' } });
+  }
+  assert.equal(last.status, 429);
+  // Even the CORRECT password is refused while locked out.
+  const correctButLocked = await app.req('POST', '/api/account/totp/disable', {
+    cookie: adminCookie,
+    body: { password: 'supersecret123' },
+  });
+  assert.equal(correctButLocked.status, 429);
+});

--- a/test/totp.test.js
+++ b/test/totp.test.js
@@ -46,13 +46,22 @@ test('verify() allows ±1 step of clock drift by default', () => {
   assert.notEqual(nextStep, null);
 });
 
-test('verify() rejects replaying a code at or before lastStep', () => {
+test('verify() rejects replaying a code at or before lastStep (within the drift window)', () => {
   const step = totp.verify(RFC_SECRET, '287082', { atMs: 59_000 }); // step 1
   assert.equal(step, 1);
-  const replay = totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: step });
-  assert.equal(replay, null);
-  const replayEarlier = totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: step + 5 });
-  assert.equal(replayEarlier, null);
+  // Same step already used — replay.
+  assert.equal(totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: step }), null);
+  // A near-future lastStep (the +1 drift step legitimately consumed) still blocks
+  // reuse of any code in the current window.
+  assert.equal(totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: step + 1 }), null);
+});
+
+test('verify() ignores a stale future lastStep so a backward clock correction cannot lock the user out', () => {
+  // lastStep sits well beyond the drift window: the clock ran fast at last login
+  // and was corrected backward (NTP). A genuine current code must still work,
+  // rather than every candidate being skipped as a replay forever.
+  const step = totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: 1 + 5 });
+  assert.equal(step, 1);
 });
 
 test('generateSecret() returns a valid base32 string that round-trips through base32Decode', () => {
@@ -66,6 +75,15 @@ test('buildOtpauthUrl() embeds the secret, issuer, and account', () => {
   assert.match(url, /^otpauth:\/\/totp\//);
   assert.match(url, /secret=JBSWY3DPEHPK3PXP/);
   assert.match(url, /alice/);
+});
+
+test('buildOtpauthUrl() percent-encodes spaces in the issuer (no "+" that apps show literally)', () => {
+  const url = totp.buildOtpauthUrl('JBSWY3DPEHPK3PXP', { account: 'alice' });
+  // The default issuer "Minecraft Server Manager" must appear as %20, never "+",
+  // so it byte-matches the label prefix and apps like Google Authenticator don't
+  // display "Minecraft+Server+Manager".
+  assert.match(url, /issuer=Minecraft%20Server%20Manager/);
+  assert.doesNotMatch(url, /issuer=[^&]*\+/);
 });
 
 test('codeAt() produces a code that verify() accepts at the same instant', () => {

--- a/test/totp.test.js
+++ b/test/totp.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const totp = require('../src/services/totp');
+
+// RFC 6238 Appendix B test vectors (SHA1, 8-digit truncation, 30s step, T0=0),
+// ASCII secret "12345678901234567890". This panel uses 6-digit codes — the
+// last 6 digits of the published 8-digit value are the same computation,
+// just kept to fewer digits, so they translate directly.
+const RFC_SECRET = totp.base32Encode(Buffer.from('12345678901234567890', 'ascii'));
+const VECTORS = [
+  { timeSec: 59, code8: '94287082' },
+  { timeSec: 1111111109, code8: '07081804' },
+  { timeSec: 1111111111, code8: '14050471' },
+  { timeSec: 1234567890, code8: '89005924' },
+  { timeSec: 2000000000, code8: '69279037' },
+];
+
+test('verify() matches the RFC 6238 published test vectors (truncated to 6 digits)', () => {
+  for (const { timeSec, code8 } of VECTORS) {
+    const code6 = code8.slice(-6);
+    const step = totp.verify(RFC_SECRET, code6, { window: 0, atMs: timeSec * 1000 });
+    assert.notEqual(step, null, `expected step for t=${timeSec}`);
+  }
+});
+
+test('verify() rejects a wrong code', () => {
+  const step = totp.verify(RFC_SECRET, '000000', { window: 0, atMs: 59_000 });
+  assert.equal(step, null);
+});
+
+test('verify() rejects a malformed code (not exactly 6 digits)', () => {
+  for (const bad of ['12345', '1234567', 'abcdef', '', '  ']) {
+    assert.equal(totp.verify(RFC_SECRET, bad, { atMs: 59_000 }), null, JSON.stringify(bad));
+  }
+});
+
+test('verify() allows ±1 step of clock drift by default', () => {
+  const step = totp.verify(RFC_SECRET, '287082', { atMs: 59_000 }); // step 1
+  assert.notEqual(step, null);
+  // One step (30s) either side of t=59 still resolves to the same step-1 code window boundary —
+  // step for t=59 is 1; step for t=59+30=89 is 2, and t=59-30=29 is 0. Verify both neighbors independently.
+  const nextStep = totp.verify(RFC_SECRET, '287082', { atMs: 89_000 }); // one step later, window=1 covers it
+  assert.notEqual(nextStep, null);
+});
+
+test('verify() rejects replaying a code at or before lastStep', () => {
+  const step = totp.verify(RFC_SECRET, '287082', { atMs: 59_000 }); // step 1
+  assert.equal(step, 1);
+  const replay = totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: step });
+  assert.equal(replay, null);
+  const replayEarlier = totp.verify(RFC_SECRET, '287082', { atMs: 59_000, lastStep: step + 5 });
+  assert.equal(replayEarlier, null);
+});
+
+test('generateSecret() returns a valid base32 string that round-trips through base32Decode', () => {
+  const secret = totp.generateSecret();
+  assert.match(secret, /^[A-Z2-7]+$/);
+  assert.equal(totp.base32Decode(secret).length, 20);
+});
+
+test('buildOtpauthUrl() embeds the secret, issuer, and account', () => {
+  const url = totp.buildOtpauthUrl('JBSWY3DPEHPK3PXP', { account: 'alice' });
+  assert.match(url, /^otpauth:\/\/totp\//);
+  assert.match(url, /secret=JBSWY3DPEHPK3PXP/);
+  assert.match(url, /alice/);
+});
+
+test('codeAt() produces a code that verify() accepts at the same instant', () => {
+  const secret = totp.generateSecret();
+  const now = Date.now();
+  const code = totp.codeAt(secret, now);
+  assert.notEqual(totp.verify(secret, code, { atMs: now, window: 0 }), null);
+});
+
+test('generateBackupCodes() returns distinct, formatted codes', () => {
+  const codes = totp.generateBackupCodes(10);
+  assert.equal(codes.length, 10);
+  assert.equal(new Set(codes).size, 10);
+  for (const c of codes) assert.match(c, /^[0-9a-f]{5}-[0-9a-f]{5}$/);
+});

--- a/views/login-2fa.hbs
+++ b/views/login-2fa.hbs
@@ -1,0 +1,16 @@
+<div class="card w-full max-w-sm p-6">
+  <div class="mb-6 flex items-center justify-center gap-2.5">
+    <span class="grid size-10 place-items-center rounded-md bg-grass-600 text-white shadow-[inset_0_-3px_0_rgb(0_0_0/0.3)]">{{{icon 'shield-check' 'size-5'}}}</span>
+    <span class="pixel text-sm">Minecraft <span class="text-ok">Server Manager</span></span>
+  </div>
+  {{#if error}}<div class="notice notice-danger mb-4 text-danger">{{error}}</div>{{/if}}
+  <form method="post" action="/login/2fa" class="space-y-4" data-disable-on-submit>
+    <div>
+      <label class="label" for="tf-code">Authenticator code</label>
+      <input class="input font-mono text-center text-lg tracking-[0.3em]" id="tf-code" name="code" inputmode="numeric" autocomplete="one-time-code" autofocus maxlength="12" placeholder="000000" required>
+      <p class="help">Enter the 6-digit code from your authenticator app, or one of your backup codes.</p>
+    </div>
+    <button class="btn btn-primary w-full" type="submit">Verify</button>
+  </form>
+  <a class="mt-4 block text-center text-xs text-ink-faint hover:text-ink" href="/login">Back to sign in</a>
+</div>

--- a/views/partials/topbar.hbs
+++ b/views/partials/topbar.hbs
@@ -23,9 +23,10 @@
     </button>
     {{! rounded-md, not a circle — the only fully-round control would break the
         blocky register. Diamond is identity color here (decorative, not meaning). }}
-    <button class="grid size-8 place-items-center rounded-md bg-diamond-700 text-xs font-bold text-white" data-menu="user-menu" data-tip="{{user.username}} ({{user.role}})">{{initial user.username}}</button>
+    <button class="grid size-8 place-items-center rounded-md bg-diamond-700 text-xs font-bold text-white" data-menu="user-menu" data-tip="{{user.username}} ({{user.role}})" data-user-totp-enabled="{{#if user.totpEnabled}}1{{/if}}">{{initial user.username}}</button>
     <template id="user-menu">
       <div class="px-3 py-2 text-xs text-ink-faint">{{user.username}} · {{user.role}}</div>
+      <button type="button" class="w-full text-left" data-open-2fa>Two-factor authentication</button>
       <form method="post" action="/logout"><button type="submit" class="w-full text-left">Sign out</button></form>
     </template>
   </div>

--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -74,7 +74,17 @@
                 </select>
               </td>
               <td>
-                {{#if totpEnabled}}
+                {{#if (eq id ../user.id)}}
+                  {{! Your own row: self-service, same modal as the topbar user menu —
+                      2FA can only ever be set up on the device you're enrolling, so
+                      there's nothing an admin can do here for someone ELSE's row. }}
+                  {{#if totpEnabled}}
+                    <span class="badge badge-ok">on</span>
+                    <button class="btn btn-ghost btn-sm" data-open-2fa data-tip="Manage your 2FA">Manage</button>
+                  {{else}}
+                    <button class="btn btn-ghost btn-sm" data-open-2fa data-tip="Set up 2FA on your account">Set up</button>
+                  {{/if}}
+                {{else if totpEnabled}}
                   <span class="badge badge-ok">on</span>
                   <button class="btn btn-ghost btn-sm" data-user-totp-reset data-tip="Reset their 2FA — they will need to re-enroll">Reset</button>
                 {{else}}

--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -61,7 +61,7 @@
     <h3 class="mb-4 font-semibold">Users</h3>
     <div class="overflow-x-auto">
       <table class="table-base" id="users-table">
-        <thead><tr><th>User</th><th>Role</th><th>Created</th><th class="text-right"></th></tr></thead>
+        <thead><tr><th>User</th><th>Role</th><th>2FA</th><th>Created</th><th class="text-right"></th></tr></thead>
         <tbody>
           {{#each users}}
             <tr data-user-id="{{id}}" data-username="{{username}}">
@@ -72,6 +72,14 @@
                   <option value="operator" {{#if (eq role 'operator')}}selected{{/if}}>operator</option>
                   <option value="viewer" {{#if (eq role 'viewer')}}selected{{/if}}>viewer</option>
                 </select>
+              </td>
+              <td>
+                {{#if totpEnabled}}
+                  <span class="badge badge-ok">on</span>
+                  <button class="btn btn-ghost btn-sm" data-user-totp-reset data-tip="Reset their 2FA — they will need to re-enroll">Reset</button>
+                {{else}}
+                  <span class="text-xs text-ink-faint">off</span>
+                {{/if}}
               </td>
               <td class="whitespace-nowrap text-xs text-ink-faint" data-ts="{{createdAt}}">{{createdAt}}</td>
               <td class="text-right">


### PR DESCRIPTION
## Summary

Adds self-service two-factor authentication (TOTP, via any standard authenticator app) — available to every role, not just admins, since protecting your own login isn't a server-management action.

- **`src/services/totp.js`** — RFC 6238 TOTP hand-rolled on `node:crypto` (base32 secrets, HMAC-SHA1, ±1 step clock drift, replay-guarded against reusing a captured code within its own window) rather than pulling in a third-party auth library for the security-critical half of this feature. Verified against RFC 6238's own published test vectors.
- **`src/services/auth.js`** — enrollment (the secret is only ever persisted once a live code from it has been verified — an abandoned setup leaves nothing behind), password-gated disable and backup-code regeneration, an admin-only force-reset for the lost-phone-and-backup-codes recovery case, and login-time verification with single-use backup codes as a fallback.
- **Login flow** — forks on `totp_enabled` via a `pendingTotpUserId` session state that `requireAuth` never treats as authenticated (verified by a direct test hitting a protected route mid-challenge), landing on a new `/login/2fa` step. It deliberately shares its lockout counter with the password step, so a correct password can't be used to reset the brute-force counter right before guessing the 6-digit code.
- **A closed gap worth flagging explicitly**: `confirmTotp` refuses to silently replace an already-enabled secret. Without that check, a hijacked-but-unlocked session (no password needed) could re-run enrollment and take over 2FA without ever touching the account's password — the UI never exposes that path, but the API shouldn't rely on that alone. Covered by a regression test.
- **UI** — QR-code enrollment via the `qrcode` package (falls back to a manual-entry secret shown alongside it), a topbar user-menu modal (enroll / regenerate backup codes / disable), and a "2FA" column + reset button in the admin Settings users table.

## Test plan

- [x] `npm test` — 196/196 pass, including new `test/totp.test.js` (RFC 6238 vectors, replay guard, malformed-code rejection) and `test/login-2fa.test.js` (full login fork, backup-code single-use, viewer self-service, admin force-reset, the already-enabled re-enrollment guard)
- [x] `npm run lint` / `npm run typecheck` / `npx prettier --check .` — all clean
- [x] Manually reasoned through the middleware ordering: `/api/account` is mounted between `requireAuth` and `requireWrite` so a read-only viewer can still manage their own 2FA, and `/login/2fa` is handled entirely inside the pre-`requireAuth` auth router so the pending (unauthenticated) session state is never treated as signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)