### PR TITLE
Make every creation-time catalog field editable after creation too

### DIFF
--- a/public/js/pages/server-settings.js
+++ b/public/js/pages/server-settings.js
@@ -60,6 +60,32 @@ function init(serverId) {
     });
   }
 
+  // ---- Advanced settings (full field catalog, same controls as the wizard) ----
+  // Pre-fill every control with the server's ACTUAL current value (falling
+  // back to the catalog default) — the wizard never needs this since it
+  // starts blank, but here each field represents something really configured.
+  const advPanel = document.getElementById('st-advanced');
+  if (advPanel) {
+    const currentEnv = parseSettingsEnv();
+    advPanel.querySelectorAll('[data-catalog-key][data-catalog-scope="env"]').forEach((el) => {
+      const key = el.dataset.catalogKey;
+      const has = Object.prototype.hasOwnProperty.call(currentEnv, key);
+      if (el.dataset.catalogType === 'boolean') {
+        el.checked = has ? currentEnv[key] === 'true' : el.dataset.catalogDefault === 'true';
+      } else if (has) {
+        el.value = currentEnv[key];
+      }
+    });
+  }
+
+  function parseSettingsEnv() {
+    try {
+      return JSON.parse(root.dataset.settingsEnv || '{}');
+    } catch {
+      return {};
+    }
+  }
+
   // Icon + accent pickers — selection lives in aria-pressed; .swatch CSS
   // draws the theme-aware ring, so JS only flips the attribute.
   bindPicker('[data-pick-icon]', (btn) => {
@@ -366,19 +392,51 @@ function init(serverId) {
         body.extraBinds = nowDocker.extraBinds;
       }
     }
-    // MOTD lives in env: merge over the server's current env (from the data
-    // island) so nothing else is lost; § codes are what vanilla renders.
-    if (motdInput) {
-      let env = {};
-      try {
-        env = JSON.parse(root.dataset.settingsEnv || '{}');
-      } catch {
-        /* island absent */
+    // MOTD + every advanced-settings field live in env: merge all changes over
+    // the server's current env (from the data island) in one pass so nothing
+    // else is lost, and only send env at all if something actually changed.
+    // Clearing a field back to empty removes the override (reverts to the
+    // image default) rather than sending an empty string.
+    {
+      const current = parseSettingsEnv();
+      const merged = { ...current };
+      let envChanged = false;
+
+      if (motdInput) {
+        const newMotd = toSectionCodes(motdInput.value);
+        if ((current.MOTD || '') !== newMotd) {
+          merged.MOTD = newMotd;
+          envChanged = true;
+        }
       }
-      const newMotd = toSectionCodes(motdInput.value);
-      if ((env.MOTD || '') !== newMotd) {
-        body.env = { ...env, MOTD: newMotd };
+
+      if (advPanel) {
+        advPanel.querySelectorAll('[data-catalog-key][data-catalog-scope="env"]').forEach((el) => {
+          const key = el.dataset.catalogKey;
+          const had = Object.prototype.hasOwnProperty.call(current, key);
+          if (el.dataset.catalogType === 'boolean') {
+            const value = el.checked ? 'true' : 'false';
+            const before = had ? current[key] : el.dataset.catalogDefault === 'true' ? 'true' : 'false';
+            if (value !== before) {
+              merged[key] = value;
+              envChanged = true;
+            }
+          } else {
+            const value = el.value.trim();
+            if (!value) {
+              if (had) {
+                delete merged[key];
+                envChanged = true;
+              }
+            } else if (value !== (had ? current[key] : '')) {
+              merged[key] = value;
+              envChanged = true;
+            }
+          }
+        });
       }
+
+      if (envChanged) body.env = merged;
     }
     const restore = setBusy(saveBtn, 'Saving…');
     try {

--- a/src/web/routes/index.js
+++ b/src/web/routes/index.js
@@ -361,6 +361,25 @@ router.get(
       // stored §-codes become &-codes for friendly editing.
       context.settingsEnv = JSON.stringify(row.env);
       context.motd = String(row.env.MOTD || '').replace(/§([0-9a-fk-orA-FK-OR])/g, '&$1');
+
+      // Every catalog field configurable at creation, minus what's covered
+      // elsewhere on this tab: identity/flavor/resources (their own cards
+      // above — flavor/version changes go through the Updates page, which
+      // handles the migration safely), players (live via whitelist/ops
+      // files on the Players tab, no restart needed), and gameplay's
+      // DIFFICULTY/PVP (live via World Controls) + MOTD (the field above) —
+      // exposing those here too would just drift out of sync with the
+      // RCON-set values. Same catalog + same field-level filter the wizard
+      // itself uses, so nothing new is exposed beyond what's already safe there.
+      const catalog = require('../../config/field-catalog');
+      const EXCLUDED_SECTIONS = new Set(['identity', 'flavor', 'resources', 'players']);
+      const EXCLUDED_KEYS = new Set(['DIFFICULTY', 'PVP', 'MOTD']);
+      context.advancedSections = catalog.SECTIONS.filter((s) => !EXCLUDED_SECTIONS.has(s.id))
+        .map((s) => ({
+          ...s,
+          fields: catalog.forSection(s.id, 'advanced').filter((f) => f.scope === 'env' && !EXCLUDED_KEYS.has(f.key)),
+        }))
+        .filter((s) => s.fields.length);
     } else if (tab === 'integrations') {
       context.integrations = {
         discord: require('../../integrations/discord').getConfig(row.id),

--- a/test/server-settings-advanced.test.js
+++ b/test/server-settings-advanced.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Regression coverage for the post-creation "Advanced settings" section on the
+// server Settings tab: every catalog field configurable at creation should be
+// editable after creation too, except what's covered elsewhere (identity/
+// flavor/resources cards, the Players tab's live whitelist/ops, World
+// Controls' live difficulty/PvP, and the MOTD field itself).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const app = require('./helpers/app');
+const db = require('../src/db');
+
+let cookie;
+
+test.before(async () => {
+  await app.start();
+  cookie = await app.adminCookie();
+  app.seedServer('srv_adv01');
+  db.run(
+    'UPDATE servers SET env_json = ? WHERE id = ?',
+    JSON.stringify({ MOTD: 'Hi', DIFFICULTY: 'normal', PVP: 'true', ALLOW_FLIGHT: 'true', MAX_PLAYERS: '15' }),
+    'srv_adv01'
+  );
+});
+
+test.after(async () => {
+  await app.stop();
+});
+
+test('settings tab renders the advanced catalog with the right exclusions', async () => {
+  const r = await app.req('GET', '/servers/srv_adv01/settings', { cookie });
+  assert.equal(r.status, 200);
+  assert.match(r.text, /id="st-advanced"/);
+
+  // Section-level: identity/flavor/resources (own cards) and players (live
+  // on the Players tab) must never appear in the advanced catalog here.
+  for (const key of ['WHITELIST', 'OPS', 'VERSION', 'PAPER_BUILD']) {
+    assert.doesNotMatch(r.text, new RegExp(`data-catalog-key="${key}"`), `${key} should be excluded`);
+  }
+  // Field-level within gameplay: DIFFICULTY/PVP (live via World Controls) and
+  // MOTD (its own field above) are excluded; the rest of gameplay is kept.
+  for (const key of ['DIFFICULTY', 'PVP', 'MOTD']) {
+    assert.doesNotMatch(r.text, new RegExp(`data-catalog-key="${key}"`), `${key} should be excluded`);
+  }
+  for (const key of ['MAX_PLAYERS', 'ALLOW_FLIGHT', 'ONLINE_MODE', 'ENABLE_RCON']) {
+    assert.match(r.text, new RegExp(`data-catalog-key="${key}"`), `${key} should be present`);
+  }
+  // Hidden catalog fields (panel-managed secrets) must never leak in either.
+  for (const key of ['RCON_PASSWORD', 'SERVER_PORT', 'RCON_PORT']) {
+    assert.doesNotMatch(r.text, new RegExp(`data-catalog-key="${key}"`), `${key} is hidden and must not render`);
+  }
+
+  // The Handlebars `default` helper/property-name collision (data-catalog-default
+  // always rendering "[object Object]") must stay fixed.
+  assert.doesNotMatch(r.text, /object Object/);
+  // A real boolean default renders as a real value, not the broken placeholder.
+  assert.match(r.text, /data-catalog-key="ENABLE_RCON"[^>]*data-catalog-default="true"/);
+});
+
+test('PATCH merges a changed catalog field over the existing env without clobbering it', async () => {
+  const patch = await app.req('PATCH', '/api/servers/srv_adv01', {
+    cookie,
+    body: { env: { MOTD: 'Hi', DIFFICULTY: 'normal', PVP: 'true', ALLOW_FLIGHT: 'true', MAX_PLAYERS: '32' } },
+  });
+  assert.equal(patch.status, 200);
+  assert.equal(patch.json.needsRecreate, true);
+
+  const row = db.get('SELECT env_json FROM servers WHERE id = ?', 'srv_adv01');
+  const env = JSON.parse(row.env_json);
+  assert.equal(env.MAX_PLAYERS, '32');
+  assert.equal(env.MOTD, 'Hi'); // untouched keys survive the merge
+  assert.equal(env.ALLOW_FLIGHT, 'true');
+});

--- a/views/partials/catalog-field.hbs
+++ b/views/partials/catalog-field.hbs
@@ -16,7 +16,7 @@
       {{#if help}}<p class="mt-1 max-w-prose text-xs leading-relaxed text-ink-faint">{{help}}</p>{{/if}}
     </div>
     <span class="msm-toggle mt-0.5 shrink-0">
-      <input type="checkbox" data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="boolean" data-catalog-default="{{default}}" {{#if default}}checked{{/if}}>
+      <input type="checkbox" data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="boolean" data-catalog-default="{{this.default}}" {{#if default}}checked{{/if}}>
       <span></span>
     </span>
   </label>
@@ -31,7 +31,7 @@
     </label>
 
     {{#if (eq type 'enum')}}
-      <select class="input max-w-sm" data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="enum" data-catalog-default="{{default}}" data-label="{{label}}">
+      <select class="input max-w-sm" data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="enum" data-catalog-default="{{this.default}}" data-label="{{label}}">
         {{#unless (isDefined default)}}<option value="">(image default)</option>{{/unless}}
         {{#each options}}
           <option value="{{value}}" {{#if (eq value ../default)}}selected{{/if}} {{#if desc}}data-desc="{{desc}}"{{/if}}>{{label}}</option>
@@ -39,17 +39,17 @@
       </select>
     {{else if (or (eq type 'number') (or (eq type 'size-mb') (eq type 'range')))}}
       <input class="input max-w-48 font-mono" type="number" inputmode="numeric"
-        data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="number" data-catalog-default="{{default}}"
+        data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="number" data-catalog-default="{{this.default}}"
         {{#if (isDefined min)}}min="{{min}}"{{/if}} {{#if (isDefined max)}}max="{{max}}"{{/if}} {{#if (isDefined step)}}step="{{step}}"{{/if}}
-        placeholder="{{#if (isDefined default)}}{{default}}{{else}}image default{{/if}}">
+        placeholder="{{#if (isDefined default)}}{{this.default}}{{else}}image default{{/if}}">
     {{else if (eq type 'list')}}
       <textarea class="input max-w-xl font-mono text-xs" rows="2"
         data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="list"
-        placeholder="{{#if (isDefined default)}}{{default}}{{else}}one entry per line{{/if}}"></textarea>
+        placeholder="{{#if (isDefined default)}}{{this.default}}{{else}}one entry per line{{/if}}"></textarea>
     {{else}}
       <input class="input max-w-xl font-mono" type="text"
-        data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="text" data-catalog-default="{{default}}"
-        placeholder="{{#if (isDefined default)}}{{default}}{{else}}image default{{/if}}">
+        data-catalog-key="{{key}}" data-catalog-scope="{{scope}}" data-catalog-type="text" data-catalog-default="{{this.default}}"
+        placeholder="{{#if (isDefined default)}}{{this.default}}{{else}}image default{{/if}}">
     {{/if}}
 
     {{#if help}}<p class="max-w-prose text-xs leading-relaxed text-ink-faint">{{help}}</p>{{/if}}

--- a/views/partials/server/settings.hbs
+++ b/views/partials/server/settings.hbs
@@ -186,6 +186,28 @@
       </div>
     </div>
   </div>
+
+  {{#if advancedSections.length}}
+  <div class="space-y-3 lg:col-span-2" id="st-advanced">
+    <div class="rounded-md border border-link/40 bg-diamond-500/10 p-3 text-xs text-ink-soft">
+      {{{icon 'info' 'size-3.5'}}} Every environment variable this server's image supports, straight from its docs — the same catalog as the creation wizard's Advanced mode, pre-filled with what's actually set. Leave a field empty to use the image default; only values you change are sent. Requires a Recreate to apply.
+    </div>
+    {{#each advancedSections}}
+      <details class="card group">
+        <summary class="flex cursor-pointer items-center gap-2.5 p-4 font-semibold marker:content-none">
+          {{{icon icon 'size-4 text-ink-faint'}}} {{label}}
+          <span class="badge ml-1">{{fields.length}}</span>
+          <span class="ml-auto text-ink-faint transition group-open:rotate-180">{{{icon 'chevron-down' 'size-4'}}}</span>
+        </summary>
+        <div class="divide-y divide-line/60 border-t border-line px-4 pb-4">
+          {{#each fields}}
+            {{> catalog-field}}
+          {{/each}}
+        </div>
+      </details>
+    {{/each}}
+  </div>
+  {{/if}}
 </div>
 
 <div class="mt-4 flex justify-end gap-2">


### PR DESCRIPTION
## Summary

Adds a catalog-driven "Advanced settings" section to the server Settings tab, reusing the wizard's own field catalog and `catalog-field` partial rather than hand-building a parallel form.

- JVM tuning, world generation, networking, RCON hooks, pack options, auto-pause, and maintenance settings are now all editable post-creation, matching what's configurable at creation time.
- Deliberately excludes:
  - `identity` / `flavor` / `resources` — already have their own cards on this tab; flavor/version changes go through the Updates page's safer migration path (backup + re-download), not a raw env-var flip.
  - `players` — live via the Players tab's whitelist/ops files, no restart needed; exposing the env-var provisioning form here too would just duplicate and drift.
  - Within `gameplay`: `DIFFICULTY`/`PVP` (live via World Controls) and `MOTD` (the tab's existing dedicated field) — same drift concern, field-level instead of section-level since the rest of `gameplay` (`MAX_PLAYERS`, `ALLOW_FLIGHT`, `ONLINE_MODE`, etc.) has no other editing path today.
- Fields are pre-filled with the server's actual current env values (falling back to the image default) rather than starting blank like the wizard does, and only genuinely changed keys are merged into the PATCH — `env_json` is replaced wholesale server-side, so the client always sends the full merged env, never a partial one.

## A bug found while building this

Hit and fixed a real pre-existing issue in `catalog-field.hbs`: a Handlebars helper named `default` (registered in `web/app.js` for template use elsewhere) shadows the catalog field's own `default` *property* on every bare `{{default}}` display — Handlebars resolves a bare top-level mustache against a same-named helper before a context property. Confirmed with an isolated repro against the `handlebars` package directly. Concretely: `data-catalog-default="{{default}}"` and every "image default" placeholder always rendered the literal string `[object Object]`, in **the creation wizard too**, not just this new section — nobody had noticed because the actually-functional bits (`{{#if default}}checked{{/if}}`, `(eq value ../default)` for enum pre-selection, `(isDefined default)` conditionals) all resolve `default` as an *argument*, which Handlebars treats as a plain property lookup — only the bare display mustache was broken. Fixed by qualifying those with `this.default`. Verified via a direct render of both the wizard and the new settings section: zero `[object Object]` occurrences, and a real boolean default (`ENABLE_RCON: true`) now correctly renders `data-catalog-default="true"` instead of the broken placeholder.

## Test plan

- [x] `npm test` — 211/215 pass (4 skip — Windows symlink tests, unrelated), including a new `test/server-settings-advanced.test.js` covering section/field-level exclusions, hidden-field leak prevention, the `[object Object]` regression, and a PATCH merge-without-clobbering check
- [x] `npm run lint` / `npm run typecheck` / `npx prettier --check .` — all clean
- [x] Manually booted the panel against a seeded server row and fetched both `/servers/new` (wizard) and `/servers/:id/settings` via curl to confirm real rendered HTML: correct section/field exclusions, no hidden secrets (`RCON_PASSWORD`, ports) leaking, and the `default` fix holding on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)