### PR TITLE
Add per-server OpenAI-compatible chatbot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,23 @@ blocked downloads stop being dead ends.
 - **Solver goes cross-platform** — the wizard's Auto-detect compatibility solver accepts
   CurseForge mods alongside Modrinth ones, mapping each CF project's full file history into the
   same loader × MC-version intersection.
+- **Per-server OpenAI-compatible chatbot** — admins can connect each Minecraft server to its own
+  Ollama or OpenAI-compatible endpoint and configure the model, invocation name (`@wizard` by
+  default), persona, join greeting, timed check-in, opt-in conversation window, and transcript
+  retention. Vanilla recipe questions use versioned game data and compact 2x2/3x3 chat grids.
+- **Optional chatbot powers** — Basic users may receive enabled self/world powers; separately named
+  Power controllers may affect another exact online player. Gifts, healing, feeding, spawn/time/
+  weather changes, and directional teleports are individually configurable and audited.
+
+### Security
+
+- Chatbot configuration and transcripts are admin-only, API keys are encrypted at rest, and LAN
+  endpoints are accepted while link-local/metadata targets are blocked. The model never receives
+  raw RCON: it can select only intent-matched structured tools whose authorization, target, item,
+  quantity, cooldown, and dry-run policy are validated again immediately before execution.
+- Gameplay powers start disabled and in dry-run mode. Player selectors are rejected, cross-player
+  targets must be online and cannot be the caller, and unsupported tool-calling models fall back to
+  conversation only.
 
 ### Fixed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ A complete, self-hosted control panel for [itzg/docker-minecraft-server](https:/
 
 ## Data & automation
 
+- **[Per-server chatbot](chatbot.md)** — local/OpenAI-compatible conversation, outreach, retained transcripts, and constrained gameplay powers.
 - **[Backups](backups.md)** — one-click snapshots, scheduled backups, and restore.
 - **[Blueprints](blueprints.md)** — capture a server's whole configuration and stamp out new ones from it.
 - **[Schedules](schedules.md)** — cron-driven restarts, backups, and commands.

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -1,0 +1,63 @@
+# Per-server Minecraft chatbot
+
+This fork adds an admin-configured chatbot to each managed Minecraft server. It connects to an
+OpenAI-compatible chat-completions endpoint, including Ollama on another LAN host. Each server has
+its own endpoint, model, invocation name, persona, transcript policy, outreach messages, and power
+policy. The default invocation is `@wizard`, and the default persona demonstrates an ancient,
+playful in-world wizard; both are editable.
+
+## Player experience
+
+- Any player can use `@wizard <message>` (or the configured invocation) for conversation and
+  deterministic, Minecraft-version-aware vanilla recipe help.
+- Join greetings and a configurable one-time play-session check-in remind players the chatbot is
+  available. `@wizard chat` opens a short opt-in conversation window; `@wizard bye` closes it.
+- **Basic users** may invoke enabled self/world powers. **Power controllers** may invoke separately
+  validated actions affecting another online player. Players in neither group remain
+  conversation-only.
+- Basic-user self-gifts use an item allowlist. Controllers may give another player any valid
+  namespaced vanilla or modded item, subject to the quantity limit and other power safeguards.
+
+## Design and security
+
+Configuration and transcripts are admin-only. The model never receives raw RCON or arbitrary
+command execution. A message exposes only the single fixed tool matching its explicit intent;
+server code validates authorization, arguments, flags, quantities, cooldowns, and exact online
+player names before executing an existing service operation. Minecraft selectors are rejected,
+cross-player actions cannot target the caller, powers begin in dry-run mode, and every attempted
+power is audited. Unsupported tool-calling models fall back to conversation only.
+
+Replies are bounded for Minecraft chat. Known vanilla recipes come from bundled versioned recipe
+data and render as stable 2x2/3x3 rows; the LLM is not trusted to invent recipe layouts. Unknown or
+modded recipes direct the player to JEI/REI rather than fabricating an answer.
+
+## Main implementation files
+
+- `src/services/wizard.js` — per-server configuration, OpenAI-compatible requests, chat handling,
+  outreach, transcript retention, and response limits.
+- `src/services/wizardPowers.js` — role checks, intent-specific tool schemas, validation, execution,
+  cooldowns, and power auditing.
+- `src/services/wizardRecipes.js` and `src/data/recipes/` — deterministic versioned recipe lookup and
+  grid formatting.
+- `src/analytics/ingest.js` — forwards parsed joins, leaves, and player chat to the chatbot.
+- `src/web/routes/wizard.js`, `public/js/pages/integrations.js`, and
+  `views/partials/server/integrations.hbs` — admin API and per-server Integrations UI.
+- `src/db/migrations/010_wizard_chat.js` through `014_wizard_power_controllers.js` — persistent schema.
+- `test/wizard.test.js` — authorization, tool-boundary, retention, outreach, and chat behavior tests.
+
+The internal `wizard` route/module/table names are retained for upgrade and API compatibility;
+“chatbot” is the user-facing product term. Likewise, the stored `power_testers_json` field maps to
+the UI's **Basic users** group.
+
+## Local storage and manual inspection
+
+All settings and retained transcripts live in the panel SQLite database at `/data/panel.db` inside
+the panel container. With the standard Compose mount, the host path is
+`${DATA_DIR_HOST}/panel.db` (for example `/opt/msm/data/panel.db`). Relevant tables are
+`wizard_configs`, `wizard_transcripts`, and `wizard_outreach`; power audits are rows in the `events`
+table with type `wizard-power`. The optional LLM API key is AES-256-GCM encrypted using the panel's
+`SESSION_SECRET`, normally persisted as `${DATA_DIR_HOST}/.session-secret`.
+
+Back up the database and stop the panel before direct SQLite edits so its WAL is handled safely.
+Using the admin UI/API is preferred because it applies validation and encryption. Keep the
+`panel.db`, `panel.db-wal`, and `panel.db-shm` files together when copying a live database.

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -37,8 +37,10 @@ modded recipes direct the player to JEI/REI rather than fabricating an answer.
   outreach, transcript retention, and response limits.
 - `src/services/wizardPowers.js` — role checks, intent-specific tool schemas, validation, execution,
   cooldowns, and power auditing.
-- `src/services/wizardRecipes.js` and `src/data/recipes/` — deterministic versioned recipe lookup and
-  grid formatting.
+- `src/services/wizardRecipes.js` — deterministic versioned recipe lookup and grid formatting. Recipe
+  and item data come from the bundled [`minecraft-data`](https://github.com/PrismarineJS/minecraft-data)
+  package. (An earlier draft of this doc pointed at a `src/data/recipes/` folder that was never
+  committed; there is no such folder, and the data lives in the package. See "Dependency footprint".)
 - `src/analytics/ingest.js` — forwards parsed joins, leaves, and player chat to the chatbot.
 - `src/web/routes/wizard.js`, `public/js/pages/integrations.js`, and
   `views/partials/server/integrations.hbs` — admin API and per-server Integrations UI.
@@ -48,6 +50,26 @@ modded recipes direct the player to JEI/REI rather than fabricating an answer.
 The internal `wizard` route/module/table names are retained for upgrade and API compatibility;
 “chatbot” is the user-facing product term. Likewise, the stored `power_testers_json` field maps to
 the UI's **Basic users** group.
+
+## Dependency footprint (`minecraft-data`)
+
+Recipe help uses the `minecraft-data` package. It is big on disk (about 429 MB installed), and it
+ships inside the production image because it is a runtime dependency, not a dev one. We are keeping it
+on purpose so recipe help works offline for every Minecraft release with no network call.
+
+Notes for whoever looks at this next (human or AI), so the size is not a surprise:
+
+- Only the Java (`pc`) data is used right now. `wizardRecipes.js` reads `minecraftData.versions.pc`
+  and the per-version `recipes`, `items`, and `blocks` tables. The files it actually touches add up
+  to roughly 15 MB across every pc version.
+- Around 330 MB of the package is `data/bedrock`, and nothing here reads it yet. We are leaving it in
+  place on purpose. If the panel ever adds Bedrock Minecraft support, the Bedrock recipe and item
+  data is already here, so the recipe feature can grow to cover Bedrock servers without adding a new
+  dependency. Start from `minecraftData.versions.bedrock` and follow the same shape as the pc path.
+- If the size ever has to come down before Bedrock support lands, there is already a pattern for it
+  in this repo. `src/services/itemRegistry.js` fetches `minecraft-data` files from the jsDelivr CDN
+  when it needs them and caches them in `api_cache`. Either that approach, or a small hand-picked
+  `src/data/recipes/` subset covering a few common versions, would shrink the image a lot.
 
 ## Local storage and manual inspection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "js-yaml": "^4.3.1",
         "lucide-static": "^1.24.0",
         "marked": "^15.0.7",
+        "minecraft-data": "^3.114.0",
         "multer": "^1.4.5-lts.2",
         "nanoid": "^3.3.8",
         "prismarine-nbt": "^2.8.0",
@@ -3838,6 +3839,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minecraft-data": {
+      "version": "3.114.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.114.0.tgz",
+      "integrity": "sha512-7V3rl5XQTMa8D8nsVl3L/UYBB+2Kn9eFR8d1MKyge6ygjJC94RExq3anHdiGnrQ65SqtmpEc999SEihSU0drIA==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "js-yaml": "^4.3.1",
     "lucide-static": "^1.24.0",
     "marked": "^15.0.7",
+    "minecraft-data": "^3.114.0",
     "multer": "^1.4.5-lts.2",
     "nanoid": "^3.3.8",
     "prismarine-nbt": "^2.8.0",

--- a/public/js/pages/integrations.js
+++ b/public/js/pages/integrations.js
@@ -23,6 +23,162 @@ function init() {
     ...root.querySelectorAll('[data-dc-event]'),
   ]);
   const cleanSp = bindDirty('sp', [document.getElementById('ig-sp-enabled'), document.getElementById('ig-sp-slug')]);
+  const cleanWz = bindDirty('wz', [
+    document.getElementById('ig-wz-enabled'),
+    document.getElementById('ig-wz-name'),
+    document.getElementById('ig-wz-url'),
+    document.getElementById('ig-wz-model'),
+    document.getElementById('ig-wz-key'),
+    document.getElementById('ig-wz-key-clear'),
+    document.getElementById('ig-wz-retention'),
+    document.getElementById('ig-wz-prompt'),
+    document.getElementById('ig-wz-welcome-enabled'),
+    document.getElementById('ig-wz-welcome-message'),
+    document.getElementById('ig-wz-checkin-minutes'),
+    document.getElementById('ig-wz-checkin-message'),
+    document.getElementById('ig-wz-conversation-minutes'),
+    document.getElementById('ig-wz-powers-enabled'),
+    document.getElementById('ig-wz-dry-run'),
+    document.getElementById('ig-wz-testers'),
+    document.getElementById('ig-wz-controllers'),
+    document.getElementById('ig-wz-gifts'),
+    document.getElementById('ig-wz-gift-max'),
+    document.getElementById('ig-wz-power-cooldown'),
+    ...root.querySelectorAll('[data-wz-power]'),
+  ]);
+
+  function wizardConnection() {
+    return {
+      baseUrl: document.getElementById('ig-wz-url')?.value.trim() || '',
+      model: document.getElementById('ig-wz-model')?.value.trim() || '',
+      apiKey: document.getElementById('ig-wz-key')?.value || undefined,
+    };
+  }
+
+  function lineList(id) {
+    return (document.getElementById(id)?.value || '')
+      .split(/[\n,]+/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  document.getElementById('ig-wz-models-load')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    await withBusy(btn, 'Loading…', async () => {
+      const res = await api(`/api/servers/${serverId}/wizard/models`, 'POST', wizardConnection());
+      if (!res.ok) return;
+      const datalist = document.getElementById('ig-wz-models');
+      datalist.replaceChildren(
+        ...res.data.models.map((name) => Object.assign(document.createElement('option'), { value: name }))
+      );
+      toast(
+        res.data.models.length ? `Found ${res.data.models.length} model(s).` : 'Connected, but no models were listed.',
+        {
+          kind: res.data.models.length ? 'success' : 'info',
+        }
+      );
+    });
+  });
+
+  document.getElementById('ig-wz-test')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    const conn = wizardConnection();
+    if (!conn.model) return toast('Enter or discover a model first.', { kind: 'error' });
+    await withBusy(btn, 'Testing…', async () => {
+      const res = await api(`/api/servers/${serverId}/wizard/test`, 'POST', conn);
+      if (res.ok) {
+        toast(`LLM replied: ${res.data.reply}`, { kind: 'success', timeout: 8000 });
+      }
+    });
+  });
+
+  document.getElementById('ig-wz-save')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    const conn = wizardConnection();
+    const body = {
+      enabled: document.getElementById('ig-wz-enabled').checked,
+      invocationName: document.getElementById('ig-wz-name').value.trim(),
+      ...conn,
+      clearApiKey: Boolean(document.getElementById('ig-wz-key-clear')?.checked),
+      retentionDays: Number(document.getElementById('ig-wz-retention').value),
+      systemPrompt: document.getElementById('ig-wz-prompt').value,
+      welcomeEnabled: document.getElementById('ig-wz-welcome-enabled').checked,
+      welcomeMessage: document.getElementById('ig-wz-welcome-message').value,
+      checkinMinutes: Number(document.getElementById('ig-wz-checkin-minutes').value),
+      checkinMessage: document.getElementById('ig-wz-checkin-message').value,
+      conversationMinutes: Number(document.getElementById('ig-wz-conversation-minutes').value),
+      powersEnabled: document.getElementById('ig-wz-powers-enabled').checked,
+      powersDryRun: document.getElementById('ig-wz-dry-run').checked,
+      powerTesters: lineList('ig-wz-testers'),
+      powerControllers: lineList('ig-wz-controllers'),
+      giftItems: lineList('ig-wz-gifts'),
+      giftMaxCount: Number(document.getElementById('ig-wz-gift-max').value),
+      powerCooldownSec: Number(document.getElementById('ig-wz-power-cooldown').value),
+      powerFlags: Object.fromEntries(
+        [...root.querySelectorAll('[data-wz-power]')].map((box) => [box.dataset.wzPower, box.checked])
+      ),
+    };
+    await withBusy(btn, 'Saving…', async () => {
+      const res = await api(`/api/servers/${serverId}/wizard`, 'POST', body);
+      if (!res.ok) return;
+      toast(
+        res.data.wizard.enabled
+          ? `Chatbot enabled. Players can say @${res.data.wizard.invocationName}.`
+          : 'Chatbot settings saved; chatbot is disabled.'
+      );
+      document.getElementById('ig-wz-key').value = '';
+      if (document.getElementById('ig-wz-key-clear')) document.getElementById('ig-wz-key-clear').checked = false;
+      cleanWz();
+    });
+  });
+
+  document.getElementById('ig-wz-transcripts')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    await withBusy(btn, 'Loading…', async () => {
+      const res = await api(`/api/servers/${serverId}/wizard/transcripts?limit=250`, 'GET');
+      if (!res.ok) return;
+      const list = document.getElementById('ig-wz-transcript-list');
+      list.replaceChildren();
+      for (const row of res.data.transcripts) {
+        const line = document.createElement('div');
+        line.className = 'border-b border-line py-2 last:border-0';
+        const meta = document.createElement('div');
+        meta.className = 'mb-1 text-ink-faint';
+        meta.textContent = `${row.created_at} · ${row.speaker}`;
+        const content = document.createElement('div');
+        content.className = row.role === 'error' ? 'text-danger' : 'whitespace-pre-wrap text-ink-soft';
+        content.textContent = row.content;
+        line.append(meta, content);
+        list.appendChild(line);
+      }
+      if (!res.data.transcripts.length) list.textContent = 'No retained chatbot conversations for this server.';
+      list.classList.remove('hidden');
+    });
+  });
+
+  document.getElementById('ig-wz-power-audit')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    await withBusy(btn, 'Loading…', async () => {
+      const res = await api(`/api/servers/${serverId}/wizard/powers/audit?limit=100`, 'GET');
+      if (!res.ok) return;
+      const list = document.getElementById('ig-wz-power-audit-list');
+      list.replaceChildren();
+      for (const event of res.data.events) {
+        const line = document.createElement('div');
+        line.className = 'border-b border-line py-2 last:border-0';
+        const meta = document.createElement('div');
+        meta.className = 'mb-1 text-ink-faint';
+        meta.textContent = `${event.created_at} · ${event.actor}`;
+        const summary = document.createElement('div');
+        summary.className = 'text-ink-soft';
+        summary.textContent = event.summary;
+        line.append(meta, summary);
+        list.appendChild(line);
+      }
+      if (!res.data.events.length) list.textContent = 'No chatbot power attempts have been recorded for this server.';
+      list.classList.remove('hidden');
+    });
+  });
 
   // ---- Discord ----
   document.getElementById('ig-dc-save')?.addEventListener('click', async (e) => {

--- a/src/analytics/ingest.js
+++ b/src/analytics/ingest.js
@@ -111,10 +111,26 @@ function handleLine(serverId, line) {
   const raw = rest;
   const evt = classify(raw);
   if (!evt) return;
+  const eventTs = dockerTs || buildTs(evt.time);
+  let inserted = false;
   try {
-    insertEvent(serverId, evt, dockerTs || buildTs(evt.time), raw);
+    inserted = insertEvent(serverId, evt, eventTs, raw);
   } catch (err) {
     console.error(`[analytics] insert failed for ${serverId}:`, err.message);
+  }
+  if (inserted && (evt.type === 'join' || evt.type === 'leave')) {
+    try {
+      const wizard = require('../services/wizard');
+      if (evt.type === 'join') {
+        wizard
+          .handleJoin(serverId, evt.player, eventTs)
+          .catch((err) => console.error(`[wizard] join ${serverId}:`, err.message));
+      } else {
+        wizard.handleLeave(serverId, evt.player);
+      }
+    } catch (err) {
+      console.error(`[wizard] presence ${serverId}:`, err.message);
+    }
   }
   // Custom chat commands (!rtp2 …): fire-and-forget — a broken command handler
   // must never break log ingestion. Lazy require avoids any module cycle.
@@ -125,6 +141,13 @@ function handleLine(serverId, line) {
         .catch((err) => console.error(`[chat-commands] ${serverId}:`, err.message));
     } catch (err) {
       console.error(`[chat-commands] ${serverId}:`, err.message);
+    }
+    try {
+      require('../services/wizard')
+        .handleChat(serverId, evt.player, evt.message)
+        .catch((err) => console.error(`[wizard] ${serverId}:`, err.message));
+    } catch (err) {
+      console.error(`[wizard] ${serverId}:`, err.message);
     }
   }
 }

--- a/src/db/migrations/010_wizard_chat.js
+++ b/src/db/migrations/010_wizard_chat.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Per-server local/OpenAI-compatible wizard configuration plus an audit-grade
+// transcript archive. Deliberately no FK on server_id: deleting a Minecraft
+// server soft-deletes its row, and wizard transcripts/config remain available
+// until their own retention policy expires.
+
+function up(db) {
+  db.exec(`
+    CREATE TABLE wizard_configs (
+      server_id       TEXT PRIMARY KEY,
+      enabled         INTEGER NOT NULL DEFAULT 0,
+      base_url        TEXT NOT NULL DEFAULT 'http://127.0.0.1:11434',
+      model           TEXT NOT NULL DEFAULT '',
+      api_key_cipher  TEXT,
+      system_prompt   TEXT NOT NULL DEFAULT '',
+      retention_days  INTEGER NOT NULL DEFAULT 7 CHECK (retention_days BETWEEN 0 AND 3650),
+      updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE wizard_transcripts (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      server_id    TEXT NOT NULL,
+      server_name  TEXT NOT NULL,
+      player       TEXT NOT NULL,
+      role         TEXT NOT NULL CHECK (role IN ('user','assistant','error')),
+      content      TEXT NOT NULL,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX idx_wizard_transcript_server_player
+      ON wizard_transcripts(server_id, player, created_at DESC);
+    CREATE INDEX idx_wizard_transcript_created
+      ON wizard_transcripts(created_at DESC);
+  `);
+}
+
+module.exports = { up };

--- a/src/db/migrations/011_wizard_invocation_name.js
+++ b/src/db/migrations/011_wizard_invocation_name.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Keep the invocation name on the retained per-server wizard configuration so
+// transcript labels still resolve after a Minecraft server is soft-deleted.
+
+function up(db) {
+  db.exec(`
+    ALTER TABLE wizard_configs
+      ADD COLUMN invocation_name TEXT NOT NULL DEFAULT 'wizard'
+      CHECK (length(invocation_name) BETWEEN 1 AND 32);
+  `);
+}
+
+module.exports = { up };

--- a/src/db/migrations/012_wizard_powers.js
+++ b/src/db/migrations/012_wizard_powers.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// Optional, tightly-scoped gameplay powers for the conversational wizard.
+// The master switch is off and dry-run is on for every existing server.
+
+function up(db) {
+  db.exec(`
+    ALTER TABLE wizard_configs ADD COLUMN powers_enabled INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE wizard_configs ADD COLUMN powers_dry_run INTEGER NOT NULL DEFAULT 1;
+    ALTER TABLE wizard_configs ADD COLUMN power_testers_json TEXT NOT NULL DEFAULT '[]';
+    ALTER TABLE wizard_configs ADD COLUMN power_flags_json TEXT NOT NULL
+      DEFAULT '{"heal":true,"feed":true,"spawn":true,"time":true,"weather":true,"gift":true}';
+    ALTER TABLE wizard_configs ADD COLUMN gift_items_json TEXT NOT NULL
+      DEFAULT '["minecraft:bread","minecraft:torch","minecraft:arrow"]';
+    ALTER TABLE wizard_configs ADD COLUMN gift_max_count INTEGER NOT NULL DEFAULT 16
+      CHECK (gift_max_count BETWEEN 1 AND 16);
+    ALTER TABLE wizard_configs ADD COLUMN power_cooldown_sec INTEGER NOT NULL DEFAULT 30
+      CHECK (power_cooldown_sec BETWEEN 3 AND 3600);
+  `);
+}
+
+module.exports = { up };

--- a/src/db/migrations/013_wizard_outreach.js
+++ b/src/db/migrations/013_wizard_outreach.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// Per-server player outreach plus one durable marker per play session. The
+// markers prevent panel restarts or watcher overlap from greeting/checking in
+// with the same player more than once during a session.
+
+function up(db) {
+  db.exec(`
+    ALTER TABLE wizard_configs ADD COLUMN welcome_enabled INTEGER NOT NULL DEFAULT 1;
+    ALTER TABLE wizard_configs ADD COLUMN welcome_message TEXT NOT NULL DEFAULT
+      'Welcome, {player}! I am {wizard}, this server''s resident guide and conversational companion. Ask me for help—or just chat—by writing {mention} followed by your message.';
+    ALTER TABLE wizard_configs ADD COLUMN checkin_minutes INTEGER NOT NULL DEFAULT 15
+      CHECK (checkin_minutes BETWEEN 0 AND 1440);
+    ALTER TABLE wizard_configs ADD COLUMN checkin_message TEXT NOT NULL DEFAULT
+      '{player}, you have been exploring for a while. How are you doing? If you need help or company, say {mention} followed by your message.';
+    ALTER TABLE wizard_configs ADD COLUMN conversation_minutes INTEGER NOT NULL DEFAULT 5
+      CHECK (conversation_minutes BETWEEN 0 AND 60);
+
+    CREATE TABLE wizard_outreach (
+      server_id         TEXT NOT NULL,
+      player            TEXT NOT NULL,
+      session_started_at TEXT NOT NULL,
+      welcomed_at       TEXT,
+      checked_in_at     TEXT,
+      PRIMARY KEY (server_id, player, session_started_at)
+    );
+    CREATE INDEX idx_wizard_outreach_session
+      ON wizard_outreach(server_id, session_started_at DESC);
+  `);
+}
+
+module.exports = { up };

--- a/src/db/migrations/014_wizard_power_controllers.js
+++ b/src/db/migrations/014_wizard_power_controllers.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// Cross-player powers are reserved for a second, explicit allowlist. Existing
+// Existing Basic users (stored as power testers) retain self-only behavior until an admin names controllers.
+
+function up(db) {
+  db.exec(`
+    ALTER TABLE wizard_configs ADD COLUMN power_controllers_json TEXT NOT NULL DEFAULT '[]';
+  `);
+}
+
+module.exports = { up };

--- a/src/server.js
+++ b/src/server.js
@@ -77,6 +77,7 @@ function startBackgroundServices(httpServer) {
   require('./services/scheduler').startScheduler();
   require('./integrations/discord').startEventBridge();
   require('./services/inventory').startSnapshotWatcher();
+  require('./services/wizard').startOutreachWatcher();
 
   // Daily maintenance: prune old analytics timeline rows + closed sessions so the
   // DB doesn't grow without bound over months of uptime. Runs shortly after boot,
@@ -85,6 +86,9 @@ function startBackgroundServices(httpServer) {
   function runMaintenance() {
     try {
       const r = require('./analytics/ingest').pruneOlderThan(ANALYTICS_RETENTION_DAYS);
+      const wizard = require('./services/wizard');
+      wizard.pruneTranscripts();
+      wizard.pruneOutreach(ANALYTICS_RETENTION_DAYS);
       if (r.events || r.sessions) {
         console.log(
           `[maintenance] pruned ${r.events} timeline rows, ${r.sessions} sessions older than ${ANALYTICS_RETENTION_DAYS}d`

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -55,11 +55,18 @@ async function assertRunning(serverId) {
   }
 }
 
+function normalizeMessageText(value, preserveNewlines = false) {
+  const text = String(value || '').replace(/\r\n?/g, '\n');
+  return (preserveNewlines ? text.replace(/\n{3,}/g, '\n\n') : text.replace(/\n+/g, ' ')).trim();
+}
+
+function deliveryLines(text, separateLines = false) {
+  return separateLines ? String(text).split('\n') : [String(text)];
+}
+
 /** Send an admin chat message. Returns the sent message (for the panel's chat log). */
 async function sendChat(serverId, opts = {}) {
-  const text = String(opts.text || '')
-    .replace(/[\r\n]+/g, ' ')
-    .trim();
+  const text = normalizeMessageText(opts.text, opts.preserveNewlines === true);
   if (!text) throw httpError(400, 'Message text is required');
   if (text.length > 512) throw httpError(400, 'Message is too long (512 chars max)');
   const mode = opts.mode === 'say' ? 'say' : 'tellraw';
@@ -75,9 +82,19 @@ async function sendChat(serverId, opts = {}) {
     cmd = ['tellraw', target, JSON.stringify(buildComponent({ ...opts, text }))];
   }
 
-  const out = cleanText(await execCapture(serverId, ['rcon-cli', ...cmd]));
-  if (out.trim() && /Unknown or incomplete|Incorrect argument|Expected|No player was found|<--\[HERE\]/i.test(out)) {
-    throw httpError(502, `The server rejected the message: ${out.split('\n')[0]}`);
+  const commands =
+    mode === 'tellraw' && opts.separateLines === true
+      ? deliveryLines(text, true).map((line) => [
+          'tellraw',
+          target,
+          JSON.stringify(buildComponent({ ...opts, text: line })),
+        ])
+      : [cmd];
+  for (const command of commands) {
+    const out = cleanText(await execCapture(serverId, ['rcon-cli', ...command]));
+    if (out.trim() && /Unknown or incomplete|Incorrect argument|Expected|No player was found|<--\[HERE\]/i.test(out)) {
+      throw httpError(502, `The server rejected the message: ${out.split('\n')[0]}`);
+    }
   }
 
   const message = {
@@ -103,4 +120,4 @@ async function sendChat(serverId, opts = {}) {
   return { ...message, actor, ts: new Date().toISOString() };
 }
 
-module.exports = { sendChat, buildComponent, normalizeTarget, COLORS, FORMATS };
+module.exports = { sendChat, buildComponent, normalizeTarget, normalizeMessageText, deliveryLines, COLORS, FORMATS };

--- a/src/services/wizard.js
+++ b/src/services/wizard.js
@@ -1,0 +1,770 @@
+// @ts-nocheck -- OpenAI-compatible response shapes vary between local servers.
+'use strict';
+
+const net = require('node:net');
+const dns = require('node:dns').promises;
+const db = require('../db');
+const secrets = require('./secrets');
+const chat = require('./chat');
+const servers = require('./servers');
+const wizardPowers = require('./wizardPowers');
+const wizardRecipes = require('./wizardRecipes');
+const httpError = require('../utils/httpError');
+const { PLAYER_NAME_RE } = require('../utils/playerName');
+
+const DEFAULT_PROMPT =
+  'You are an ancient, playful wizard who lives inside this Minecraft world. ' +
+  'Address players by name when natural. Keep every response under 350 characters. ' +
+  'You may converse, tell stories, tease gently, and offer Minecraft advice. ' +
+  'Never claim that you performed a gameplay action unless an available tool completed successfully.';
+const DEFAULT_WELCOME_MESSAGE =
+  "Welcome, {player}! I am {chatbot}, this server's resident guide and conversational companion. " +
+  'Ask me for help—or just chat—by writing {mention} followed by your message.';
+const DEFAULT_CHECKIN_MESSAGE =
+  '{player}, you have been exploring for a while. How are you doing? ' +
+  'If you need help or company, say {mention} followed by your message.';
+const INVOCATION_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,31}$/;
+const MAX_REPLY = 350;
+const HISTORY_MESSAGES = 20;
+const REQUEST_TIMEOUT_MS = 30_000;
+const inflight = new Set();
+const cooldowns = new Map();
+const conversationWindows = new Map();
+let outreachTimer = null;
+let outreachRunning = false;
+
+function normalizeInvocationName(raw) {
+  const name = String(raw || 'wizard').trim();
+  if (!INVOCATION_NAME_RE.test(name)) {
+    throw httpError(
+      400,
+      'The invocation name must start with a letter and use only letters, numbers, _ or - (32 characters max)'
+    );
+  }
+  return name;
+}
+
+function invocationPattern(name = 'wizard') {
+  const escaped = normalizeInvocationName(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^@${escaped}(?:\\s+([\\s\\S]*))?$`, 'i');
+}
+
+function assistantLabel(name = 'wizard') {
+  const normalized = normalizeInvocationName(name);
+  return normalized[0].toUpperCase() + normalized.slice(1);
+}
+
+function normalizeOutreachMessage(raw, fallback) {
+  const message = String(raw ?? fallback)
+    .replace(/[\r\n\x00-\x1f\x7f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return (message || fallback).slice(0, 400);
+}
+
+const TRIGGER_RE = invocationPattern('wizard');
+
+function row(serverId) {
+  return db.get('SELECT * FROM wizard_configs WHERE server_id = ?', serverId);
+}
+
+function parseJson(raw, fallback) {
+  try {
+    const value = JSON.parse(raw);
+    return value === null ? fallback : value;
+  } catch {
+    return fallback;
+  }
+}
+
+function getConfig(serverId, { includeSecret = false } = {}) {
+  const r = row(serverId);
+  const key = r && r.api_key_cipher ? secrets.tryDecrypt(r.api_key_cipher) : null;
+  return {
+    enabled: Boolean(r && r.enabled),
+    baseUrl: (r && r.base_url) || 'http://127.0.0.1:11434',
+    model: (r && r.model) || '',
+    invocationName: (r && r.invocation_name) || 'wizard',
+    systemPrompt: (r && r.system_prompt) || DEFAULT_PROMPT,
+    retentionDays: r ? r.retention_days : 7,
+    welcomeEnabled: r ? Boolean(r.welcome_enabled) : true,
+    welcomeMessage: (r && r.welcome_message) || DEFAULT_WELCOME_MESSAGE,
+    checkinMinutes: r ? r.checkin_minutes : 15,
+    checkinMessage: (r && r.checkin_message) || DEFAULT_CHECKIN_MESSAGE,
+    conversationMinutes: r ? r.conversation_minutes : 5,
+    hasApiKey: Boolean(key),
+    powersEnabled: Boolean(r && r.powers_enabled),
+    powersDryRun: r ? Boolean(r.powers_dry_run) : true,
+    powerTesters: wizardPowers.normalizeTesters(parseJson(r?.power_testers_json || '[]', [])),
+    powerControllers: wizardPowers.normalizeControllers(parseJson(r?.power_controllers_json || '[]', [])),
+    powerFlags: wizardPowers.normalizeFlags(parseJson(r?.power_flags_json || '{}', {})),
+    giftItems: wizardPowers.normalizeGiftItems(
+      parseJson(r?.gift_items_json || JSON.stringify(wizardPowers.DEFAULT_GIFTS), wizardPowers.DEFAULT_GIFTS)
+    ),
+    giftMaxCount: r ? r.gift_max_count : 16,
+    powerCooldownSec: r ? r.power_cooldown_sec : 30,
+    ...(includeSecret ? { apiKey: key || '' } : {}),
+  };
+}
+
+function normalizeBaseUrl(raw) {
+  let u;
+  try {
+    u = new URL(String(raw || '').trim());
+  } catch {
+    throw httpError(400, 'Enter a valid LLM URL, such as http://192.168.1.50:11434');
+  }
+  if (!['http:', 'https:'].includes(u.protocol)) throw httpError(400, 'The LLM URL must use http or https');
+  if (u.username || u.password) throw httpError(400, 'Put credentials in the API key field, not in the URL');
+  if (u.search || u.hash) throw httpError(400, 'The LLM base URL cannot contain a query string or fragment');
+  const host = u.hostname.replace(/^\[|\]$/g, '');
+  if (net.isIPv4(host)) {
+    const [a, b] = host.split('.').map(Number);
+    if (a === 0 || (a === 169 && b === 254) || a >= 224) {
+      throw httpError(400, 'Link-local, unspecified, multicast, and reserved LLM addresses are not allowed');
+    }
+  } else if (net.isIPv6(host)) {
+    const h = host.toLowerCase();
+    if (h === '::' || h.startsWith('fe80') || h.startsWith('ff')) {
+      throw httpError(400, 'Link-local, unspecified, and multicast LLM addresses are not allowed');
+    }
+  }
+  u.pathname = u.pathname.replace(/\/+$/, '');
+  return u.toString().replace(/\/$/, '');
+}
+
+function openAiBase(baseUrl) {
+  return /\/v1$/i.test(baseUrl) ? baseUrl : `${baseUrl}/v1`;
+}
+
+function saveConfig(serverId, input, _options = {}) {
+  const previous = row(serverId);
+  const baseUrl = normalizeBaseUrl(input.baseUrl);
+  const model = String(input.model || '').trim();
+  const invocationName = normalizeInvocationName(input.invocationName ?? previous?.invocation_name ?? 'wizard');
+  if (input.enabled && !model) throw httpError(400, 'Choose or enter a model before enabling the chatbot');
+  const retentionDays = Math.max(0, Math.min(3650, Math.trunc(Number(input.retentionDays))));
+  const prompt = String(input.systemPrompt || '').trim() || DEFAULT_PROMPT;
+  const priorCfg = getConfig(serverId);
+  const welcomeEnabled = input.welcomeEnabled ?? priorCfg.welcomeEnabled;
+  const welcomeMessage = normalizeOutreachMessage(input.welcomeMessage, priorCfg.welcomeMessage);
+  const checkinMinutes = Math.trunc(Number(input.checkinMinutes ?? priorCfg.checkinMinutes));
+  const checkinMessage = normalizeOutreachMessage(input.checkinMessage, priorCfg.checkinMessage);
+  const conversationMinutes = Math.trunc(Number(input.conversationMinutes ?? priorCfg.conversationMinutes));
+  if (!Number.isInteger(checkinMinutes) || checkinMinutes < 0 || checkinMinutes > 1440) {
+    throw httpError(400, 'Chatbot check-in time must be between 0 and 1440 minutes');
+  }
+  if (!Number.isInteger(conversationMinutes) || conversationMinutes < 0 || conversationMinutes > 60) {
+    throw httpError(400, 'Chatbot conversation mode must be between 0 and 60 minutes');
+  }
+  const powerTesters = wizardPowers.normalizeTesters(input.powerTesters ?? priorCfg.powerTesters);
+  const powerControllers = wizardPowers.normalizeControllers(input.powerControllers ?? priorCfg.powerControllers);
+  const powerFlags = wizardPowers.normalizeFlags(input.powerFlags ?? priorCfg.powerFlags);
+  const giftItems = wizardPowers.normalizeGiftItems(input.giftItems ?? priorCfg.giftItems);
+  const giftMaxCount = Math.trunc(Number(input.giftMaxCount ?? priorCfg.giftMaxCount));
+  const powerCooldownSec = Math.trunc(Number(input.powerCooldownSec ?? priorCfg.powerCooldownSec));
+  if (giftMaxCount < 1 || giftMaxCount > 16) throw httpError(400, 'Maximum gift quantity must be between 1 and 16');
+  if (powerCooldownSec < 3 || powerCooldownSec > 3600) {
+    throw httpError(400, 'Power cooldown must be between 3 and 3600 seconds');
+  }
+  let cipher = previous ? previous.api_key_cipher : null;
+  if (input.clearApiKey) cipher = null;
+  else if (typeof input.apiKey === 'string' && input.apiKey.trim()) cipher = secrets.encrypt(input.apiKey.trim());
+  db.run(
+    `INSERT INTO wizard_configs
+       (server_id, enabled, base_url, model, api_key_cipher, system_prompt, retention_days, invocation_name,
+        powers_enabled, powers_dry_run, power_testers_json, power_flags_json, gift_items_json,
+        gift_max_count, power_cooldown_sec, power_controllers_json, welcome_enabled, welcome_message,
+        checkin_minutes, checkin_message, conversation_minutes, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+     ON CONFLICT(server_id) DO UPDATE SET
+       enabled = excluded.enabled, base_url = excluded.base_url, model = excluded.model,
+       api_key_cipher = excluded.api_key_cipher, system_prompt = excluded.system_prompt,
+       retention_days = excluded.retention_days, invocation_name = excluded.invocation_name,
+       powers_enabled = excluded.powers_enabled, powers_dry_run = excluded.powers_dry_run,
+       power_testers_json = excluded.power_testers_json, power_flags_json = excluded.power_flags_json,
+       gift_items_json = excluded.gift_items_json, gift_max_count = excluded.gift_max_count,
+       power_cooldown_sec = excluded.power_cooldown_sec,
+       power_controllers_json = excluded.power_controllers_json,
+       welcome_enabled = excluded.welcome_enabled, welcome_message = excluded.welcome_message,
+       checkin_minutes = excluded.checkin_minutes, checkin_message = excluded.checkin_message,
+       conversation_minutes = excluded.conversation_minutes,
+       updated_at = datetime('now')`,
+    serverId,
+    input.enabled ? 1 : 0,
+    baseUrl,
+    model,
+    cipher,
+    prompt,
+    retentionDays,
+    invocationName,
+    (input.powersEnabled ?? priorCfg.powersEnabled) ? 1 : 0,
+    (input.powersDryRun ?? priorCfg.powersDryRun) ? 1 : 0,
+    JSON.stringify(powerTesters),
+    JSON.stringify(powerFlags),
+    JSON.stringify(giftItems),
+    giftMaxCount,
+    powerCooldownSec,
+    JSON.stringify(powerControllers),
+    welcomeEnabled ? 1 : 0,
+    welcomeMessage,
+    checkinMinutes,
+    checkinMessage,
+    conversationMinutes
+  );
+  pruneTranscripts(serverId);
+  return getConfig(serverId);
+}
+
+function authHeaders(cfg) {
+  return cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {};
+}
+
+function blockedAddress(address) {
+  if (net.isIPv4(address)) {
+    const [a, b] = address.split('.').map(Number);
+    return a === 0 || (a === 169 && b === 254) || a >= 224;
+  }
+  if (net.isIPv6(address)) {
+    const h = address.toLowerCase();
+    return h === '::' || h.startsWith('fe80') || h.startsWith('ff');
+  }
+  return true;
+}
+
+async function assertAllowedEndpoint(rawUrl) {
+  const u = new URL(rawUrl);
+  const host = u.hostname.replace(/^\[|\]$/g, '');
+  let addresses = [host];
+  if (!net.isIP(host)) {
+    try {
+      addresses = (await dns.lookup(host, { all: true })).map((r) => r.address);
+    } catch {
+      throw httpError(502, `Could not resolve LLM host ${host}`);
+    }
+  }
+  if (!addresses.length || addresses.some(blockedAddress)) {
+    throw httpError(400, 'The LLM host resolves to a link-local, unspecified, multicast, or reserved address');
+  }
+}
+
+async function fetchJson(url, options = {}) {
+  await assertAllowedEndpoint(url);
+  let res;
+  try {
+    res = await fetch(url, { ...options, redirect: 'error', signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+  } catch (err) {
+    throw httpError(502, `Could not reach the LLM server: ${err.message}`);
+  }
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    const detail = body?.error?.message || body?.error || body?.message || `HTTP ${res.status}`;
+    throw httpError(502, `LLM server rejected the request: ${String(detail).slice(0, 300)}`);
+  }
+  return body;
+}
+
+async function listModels(serverId, override = {}) {
+  const cfg = { ...getConfig(serverId, { includeSecret: true }), ...override };
+  cfg.baseUrl = normalizeBaseUrl(cfg.baseUrl);
+  const headers = { Accept: 'application/json', ...authHeaders(cfg) };
+  try {
+    const body = await fetchJson(`${openAiBase(cfg.baseUrl)}/models`, { headers });
+    const names = Array.isArray(body?.data) ? body.data.map((m) => m.id).filter(Boolean) : [];
+    if (names.length) return [...new Set(names)].sort();
+  } catch {
+    // Ollama's native model-list endpoint is the compatibility fallback.
+  }
+  const body = await fetchJson(`${cfg.baseUrl.replace(/\/v1$/i, '')}/api/tags`, { headers });
+  return [...new Set((body?.models || []).map((m) => m.name || m.model).filter(Boolean))].sort();
+}
+
+async function completionMessage(
+  serverId,
+  player,
+  prompt,
+  { persist = true, override = {}, allowPowers = false } = {}
+) {
+  const cfg = { ...getConfig(serverId, { includeSecret: true }), ...override };
+  if (!cfg.model) throw httpError(409, 'The chatbot has no model configured');
+  const history = persist && cfg.retentionDays > 0 ? recentConversation(serverId, player) : [];
+  const tools = allowPowers ? wizardPowers.toolsFor(cfg, player, prompt) : [];
+  const powerGuard = tools.length
+    ? 'You have only the provided tools. A tool always affects the requesting player when named self. Call at most one tool for a request. Never claim an action happened unless you call a tool.'
+    : 'No gameplay tools are available for this player. Continue conversationally and never claim that you changed the game.';
+  const request = {
+    model: cfg.model,
+    temperature: 0.8,
+    max_tokens: 180,
+    stream: false,
+    messages: [
+      {
+        role: 'system',
+        content: `${cfg.systemPrompt}\n\nSecurity rule: ${powerGuard} Return ordinary conversation as plain text, never JSON or a pretend function call.`,
+      },
+      ...history.map((m) => ({ role: m.role, content: m.role === 'user' ? `${m.player}: ${m.content}` : m.content })),
+      { role: 'user', content: `${player}: ${prompt}` },
+    ],
+  };
+  if (tools.length) {
+    request.tools = tools;
+    request.tool_choice = 'auto';
+  }
+  const url = `${openAiBase(normalizeBaseUrl(cfg.baseUrl))}/chat/completions`;
+  const options = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json', ...authHeaders(cfg) },
+    body: JSON.stringify(request),
+  };
+  let body;
+  try {
+    body = await fetchJson(url, options);
+  } catch (err) {
+    // Older local models may support chat completions but not OpenAI tools.
+    // Retry without tools so they remain safely conversation-only.
+    if (!tools.length) throw err;
+    delete request.tools;
+    delete request.tool_choice;
+    request.messages[0].content = `${cfg.systemPrompt}\n\nSecurity rule: No gameplay tools are available for this player. Continue conversationally, never claim that you changed the game, and return plain text rather than JSON or a pretend function call.`;
+    body = await fetchJson(url, { ...options, body: JSON.stringify(request) });
+  }
+  const message = body?.choices?.[0]?.message;
+  if (!message || typeof message !== 'object') throw httpError(502, 'The LLM returned an empty response');
+  return { message, cfg };
+}
+
+function cleanReply(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) throw httpError(502, 'The LLM returned an empty response');
+  let text = raw.trim();
+  if (text.startsWith('{') && text.endsWith('}')) {
+    try {
+      const envelope = JSON.parse(text);
+      const inner = envelope && typeof envelope === 'object' ? envelope.parameters : null;
+      const candidate = [
+        envelope?.content,
+        envelope?.text,
+        envelope?.message,
+        envelope?.response,
+        envelope?.story,
+        inner?.content,
+        inner?.text,
+        inner?.message,
+        inner?.response,
+        inner?.story,
+      ].find((value) => typeof value === 'string' && value.trim());
+      if (candidate) text = candidate;
+      else if (envelope?.name || envelope?.function || envelope?.tool_calls || envelope?.parameters) {
+        throw httpError(502, 'The LLM returned a tool-shaped response instead of conversational text');
+      }
+    } catch (err) {
+      if (err.status) throw err;
+      // Malformed prose that merely begins/ends with braces is still treated as
+      // ordinary text; the normal chat sanitizer and boundary truncation apply.
+    }
+  }
+  text = text.replace(/[\r\n\x00-\x1f\x7f]+/g, ' ').trim();
+  if (text.length <= MAX_REPLY) return text;
+
+  const prefix = text.slice(0, MAX_REPLY - 2);
+  const minimumUsefulCut = Math.floor(MAX_REPLY * 0.55);
+  const sentenceEnds = [...prefix.matchAll(/[.!?](?=\s|$)/g)];
+  const sentence = sentenceEnds.findLast((match) => match.index >= minimumUsefulCut);
+  let cut = sentence ? sentence.index + 1 : prefix.lastIndexOf(' ');
+  if (cut < minimumUsefulCut) cut = prefix.length;
+  return `${prefix.slice(0, cut).trimEnd()} …`;
+}
+
+async function complete(serverId, player, prompt, options = {}) {
+  const { message } = await completionMessage(serverId, player, prompt, options);
+  return cleanReply(message.content);
+}
+
+async function testConnection(serverId, override) {
+  return complete(serverId, 'Admin', 'Reply with exactly: The chatbot is ready.', {
+    persist: false,
+    override,
+  });
+}
+
+function insertTranscript(serverId, player, role, content) {
+  const cfg = getConfig(serverId);
+  if (cfg.retentionDays <= 0) return;
+  const server = db.get('SELECT display_name FROM servers WHERE id = ?', serverId);
+  db.run(
+    'INSERT INTO wizard_transcripts (server_id, server_name, player, role, content) VALUES (?, ?, ?, ?, ?)',
+    serverId,
+    (server && server.display_name) || serverId,
+    player,
+    role,
+    String(content).slice(0, 4000)
+  );
+}
+
+function recentConversation(serverId, player) {
+  return db
+    .all(
+      `SELECT player, role, content FROM wizard_transcripts
+       WHERE server_id = ? AND player = ? AND role IN ('user','assistant')
+       ORDER BY id DESC LIMIT ?`,
+      serverId,
+      player,
+      HISTORY_MESSAGES
+    )
+    .reverse();
+}
+
+function listTranscripts({ serverId = null, limit = 250 } = {}) {
+  const n = Math.max(1, Math.min(2000, Math.trunc(Number(limit)) || 250));
+  const rows = serverId
+    ? db.all(
+        `SELECT t.*, COALESCE(c.invocation_name, 'wizard') AS invocation_name
+         FROM wizard_transcripts t LEFT JOIN wizard_configs c ON c.server_id = t.server_id
+         WHERE t.server_id = ? ORDER BY t.id DESC LIMIT ?`,
+        serverId,
+        n
+      )
+    : db.all(
+        `SELECT t.*, COALESCE(c.invocation_name, 'wizard') AS invocation_name
+         FROM wizard_transcripts t LEFT JOIN wizard_configs c ON c.server_id = t.server_id
+         ORDER BY t.id DESC LIMIT ?`,
+        n
+      );
+  return rows.map((r) => {
+    const bot = assistantLabel(r.invocation_name);
+    return {
+      ...r,
+      speaker: r.role === 'user' ? r.player : r.role === 'assistant' ? bot : `${bot} error`,
+    };
+  });
+}
+
+function clearTranscripts(serverId = null) {
+  return serverId
+    ? db.run('DELETE FROM wizard_transcripts WHERE server_id = ?', serverId)
+    : db.run('DELETE FROM wizard_transcripts');
+}
+
+function pruneTranscripts(serverId = null) {
+  if (serverId) {
+    const cfg = getConfig(serverId);
+    if (cfg.retentionDays === 0) return db.run('DELETE FROM wizard_transcripts WHERE server_id = ?', serverId);
+    return db.run(
+      "DELETE FROM wizard_transcripts WHERE server_id = ? AND created_at < datetime('now', ?)",
+      serverId,
+      `-${cfg.retentionDays} days`
+    );
+  }
+  return db.run(`DELETE FROM wizard_transcripts
+    WHERE EXISTS (
+      SELECT 1 FROM wizard_configs c
+      WHERE c.server_id = wizard_transcripts.server_id
+        AND (c.retention_days = 0 OR wizard_transcripts.created_at < datetime('now', '-' || c.retention_days || ' days'))
+    )`);
+}
+
+function pruneOutreach(days = 90) {
+  const bounded = Math.max(1, Math.min(3650, Math.trunc(Number(days)) || 90));
+  return db.run("DELETE FROM wizard_outreach WHERE session_started_at < datetime('now', ?)", `-${bounded} days`);
+}
+
+function renderOutreachMessage(template, cfg, player) {
+  const replacements = {
+    player: String(player),
+    chatbot: assistantLabel(cfg.invocationName),
+    wizard: assistantLabel(cfg.invocationName),
+    mention: `@${cfg.invocationName}`,
+    minutes: String(cfg.checkinMinutes),
+  };
+  return normalizeOutreachMessage(template, DEFAULT_CHECKIN_MESSAGE)
+    .replace(/\{(player|chatbot|wizard|mention|minutes)\}/gi, (_match, key) => replacements[key.toLowerCase()])
+    .slice(0, 450);
+}
+
+async function sendWizardText(serverId, cfg, target, text) {
+  await chat.sendChat(serverId, {
+    actor: cfg.invocationName,
+    target,
+    text: `[${assistantLabel(cfg.invocationName)}] ${text}`,
+    color: 'light_purple',
+    italic: true,
+  });
+}
+
+function claimOutreach(serverId, player, sessionStartedAt, field, now) {
+  if (!['welcomed_at', 'checked_in_at'].includes(field)) throw new Error('Invalid chatbot outreach field');
+  db.run(
+    `INSERT OR IGNORE INTO wizard_outreach (server_id, player, session_started_at)
+     VALUES (?, ?, ?)`,
+    serverId,
+    player,
+    sessionStartedAt
+  );
+  return (
+    Number(
+      db.run(
+        `UPDATE wizard_outreach SET ${field} = ?
+         WHERE server_id = ? AND player = ? AND session_started_at = ? AND ${field} IS NULL`,
+        now,
+        serverId,
+        player,
+        sessionStartedAt
+      ).changes
+    ) === 1
+  );
+}
+
+async function handleJoin(serverId, player, joinedAt = new Date().toISOString(), { send = sendWizardText } = {}) {
+  // A join always starts a fresh interaction context, even when greetings are
+  // disabled or the prior disconnect line was missed.
+  closeConversation(serverId, player);
+  const cfg = getConfig(serverId);
+  if (!cfg.enabled || !cfg.welcomeEnabled || !PLAYER_NAME_RE.test(String(player))) return false;
+  const now = new Date().toISOString();
+  if (!claimOutreach(serverId, player, joinedAt, 'welcomed_at', now)) return false;
+  const message = renderOutreachMessage(cfg.welcomeMessage, cfg, player);
+  try {
+    await send(serverId, cfg, '@a', message);
+    insertTranscript(serverId, player, 'assistant', message);
+    return true;
+  } catch (err) {
+    insertTranscript(serverId, player, 'error', `Join greeting failed: ${String(err.message || err)}`);
+    console.warn(`[wizard] join greeting ${serverId}/${player}: ${err.message}`);
+    return false;
+  }
+}
+
+async function processCheckins({ now = new Date(), send = sendWizardText } = {}) {
+  const nowMs = now.getTime();
+  const rows = db.all(
+    `SELECT ps.server_id, ps.player, ps.started_at
+     FROM player_sessions ps JOIN wizard_configs c ON c.server_id = ps.server_id
+     WHERE ps.ended_at IS NULL AND c.enabled = 1 AND c.checkin_minutes > 0`
+  );
+  let sent = 0;
+  for (const row of rows) {
+    const cfg = getConfig(row.server_id);
+    const startedMs = Date.parse(row.started_at);
+    if (!Number.isFinite(startedMs) || nowMs - startedMs < cfg.checkinMinutes * 60_000) continue;
+    if (!claimOutreach(row.server_id, row.player, row.started_at, 'checked_in_at', now.toISOString())) continue;
+    // The player may have left between the candidate query and this claim.
+    if (
+      !db.get(
+        'SELECT 1 FROM player_sessions WHERE server_id = ? AND player = ? AND started_at = ? AND ended_at IS NULL',
+        row.server_id,
+        row.player,
+        row.started_at
+      )
+    ) {
+      continue;
+    }
+    const message = renderOutreachMessage(cfg.checkinMessage, cfg, row.player);
+    try {
+      await send(row.server_id, cfg, row.player, message);
+      insertTranscript(row.server_id, row.player, 'assistant', message);
+      sent += 1;
+    } catch (err) {
+      insertTranscript(row.server_id, row.player, 'error', `Check-in failed: ${String(err.message || err)}`);
+      console.warn(`[wizard] check-in ${row.server_id}/${row.player}: ${err.message}`);
+    }
+  }
+  return sent;
+}
+
+function startOutreachWatcher({ intervalMs = 30_000 } = {}) {
+  if (outreachTimer) return;
+  const run = async () => {
+    if (outreachRunning) return;
+    outreachRunning = true;
+    try {
+      await processCheckins();
+    } catch (err) {
+      console.error('[wizard] outreach watcher:', err.message);
+    } finally {
+      outreachRunning = false;
+    }
+  };
+  run();
+  outreachTimer = setInterval(run, intervalMs);
+  outreachTimer.unref?.();
+}
+
+function stopOutreachWatcher() {
+  if (outreachTimer) clearInterval(outreachTimer);
+  outreachTimer = null;
+}
+
+function conversationKey(serverId, player) {
+  return `${serverId}:${String(player).toLowerCase()}`;
+}
+
+function conversationActive(serverId, player, now = Date.now()) {
+  const key = conversationKey(serverId, player);
+  const expiresAt = conversationWindows.get(key) || 0;
+  if (expiresAt <= now) {
+    conversationWindows.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function openConversation(serverId, player, minutes, now = Date.now()) {
+  conversationWindows.set(conversationKey(serverId, player), now + minutes * 60_000);
+}
+
+function closeConversation(serverId, player) {
+  return conversationWindows.delete(conversationKey(serverId, player));
+}
+
+function handleLeave(serverId, player) {
+  closeConversation(serverId, player);
+}
+
+function conversationCommand(text) {
+  const value = String(text || '').trim();
+  if (/^(?:chat|conversation|talk)(?:\s+mode)?$|^let'?s\s+(?:chat|talk)$/i.test(value)) return 'open';
+  if (/^(?:bye|goodbye|stop|stop\s+chat|close\s+chat)$/i.test(value)) return 'close';
+  return null;
+}
+
+async function handleChat(serverId, player, message) {
+  const cfg = getConfig(serverId);
+  if (!cfg.enabled || !PLAYER_NAME_RE.test(String(player))) return false;
+  const raw = String(message || '').trim();
+  const match = invocationPattern(cfg.invocationName).exec(raw);
+  const activeConversation = cfg.conversationMinutes > 0 && conversationActive(serverId, player);
+  if (!match && (!activeConversation || !raw || /^[!/@]/.test(raw))) return false;
+  const label = assistantLabel(cfg.invocationName);
+  const invokedText = match ? String(match[1] || '').trim() : '';
+  const modeCommand = match ? conversationCommand(invokedText) : null;
+  if (modeCommand === 'open') {
+    if (activeConversation) {
+      openConversation(serverId, player, cfg.conversationMinutes);
+      return true;
+    }
+    const reply = cfg.conversationMinutes
+      ? `Conversation mode is open for ${cfg.conversationMinutes} minute${cfg.conversationMinutes === 1 ? '' : 's'}. You can reply without @${cfg.invocationName}; say @${cfg.invocationName} bye to close it.`
+      : `Conversation mode is disabled on this server. Keep using @${cfg.invocationName} before each message.`;
+    if (cfg.conversationMinutes) openConversation(serverId, player, cfg.conversationMinutes);
+    insertTranscript(serverId, player, 'assistant', reply);
+    await sendWizardText(serverId, cfg, player, reply).catch(() => {});
+    return true;
+  }
+  if (modeCommand === 'close') {
+    if (!closeConversation(serverId, player)) return true;
+    const reply = `Conversation mode is closed. Call @${cfg.invocationName} whenever you need me.`;
+    insertTranscript(serverId, player, 'assistant', reply);
+    await sendWizardText(serverId, cfg, player, reply).catch(() => {});
+    return true;
+  }
+  const prompt = (match ? invokedText || `Greetings, ${label}.` : raw).slice(0, 1000);
+  const key = conversationKey(serverId, player);
+  if (inflight.has(key)) return true;
+  const last = cooldowns.get(key) || 0;
+  if (Date.now() - last < 3000) return true;
+  inflight.add(key);
+  cooldowns.set(key, Date.now());
+  let exchangeRecorded = false;
+  let powerAttempted = false;
+  try {
+    const recipeReply = wizardRecipes.recipeReply(prompt, servers.getServer(serverId)?.mc_version);
+    if (recipeReply) {
+      insertTranscript(serverId, player, 'user', prompt);
+      insertTranscript(serverId, player, 'assistant', recipeReply);
+      exchangeRecorded = true;
+      await chat.sendChat(serverId, {
+        actor: cfg.invocationName,
+        target: '@a',
+        text: `[${label}] ${recipeReply}`,
+        color: 'light_purple',
+        italic: true,
+        preserveNewlines: true,
+        separateLines: true,
+      });
+      if (conversationActive(serverId, player)) openConversation(serverId, player, cfg.conversationMinutes);
+      return true;
+    }
+    const { message, cfg: powerCfg } = await completionMessage(serverId, player, prompt, { allowPowers: true });
+    powerAttempted = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+    let powerRequest;
+    try {
+      powerRequest = wizardPowers.parseToolCall(message, powerCfg, player, prompt);
+    } catch (err) {
+      wizardPowers.recordRejection(serverId, player, err.message);
+      throw err;
+    }
+    const result = powerRequest ? await wizardPowers.execute(serverId, player, powerRequest, powerCfg) : null;
+    const reply = result ? result.message : cleanReply(message.content);
+    insertTranscript(serverId, player, 'user', prompt);
+    insertTranscript(serverId, player, 'assistant', reply);
+    exchangeRecorded = true;
+    await chat.sendChat(serverId, {
+      actor: cfg.invocationName,
+      target: '@a',
+      text: `[${label}] ${reply}`,
+      color: 'light_purple',
+      italic: true,
+    });
+    if (conversationActive(serverId, player)) openConversation(serverId, player, cfg.conversationMinutes);
+    return true;
+  } catch (err) {
+    // If delivery failed after a successful completion, the exchange is already
+    // retained; do not duplicate the player's line while recording the failure.
+    if (!exchangeRecorded) insertTranscript(serverId, player, 'user', prompt);
+    insertTranscript(serverId, player, 'error', String(err.message || err));
+    console.warn(`[wizard] ${serverId}/${player}: ${err.message}`);
+    const safePowerMessage = powerAttempted
+      ? err.status === 429
+        ? err.message
+        : err.status >= 400 && err.status < 500
+          ? 'I could not safely interpret that power request. Please ask for one power at a time.'
+          : null
+      : null;
+    await chat
+      .sendChat(serverId, {
+        actor: cfg.invocationName,
+        target: player,
+        text: `[${label}] ${safePowerMessage || 'The veil is cloudy just now. Ask me again shortly.'}`,
+        color: 'dark_purple',
+        italic: true,
+      })
+      .catch(() => {});
+    return true;
+  } finally {
+    inflight.delete(key);
+  }
+}
+
+module.exports = {
+  DEFAULT_PROMPT,
+  DEFAULT_WELCOME_MESSAGE,
+  DEFAULT_CHECKIN_MESSAGE,
+  TRIGGER_RE,
+  INVOCATION_NAME_RE,
+  normalizeInvocationName,
+  invocationPattern,
+  assistantLabel,
+  getConfig,
+  saveConfig,
+  listModels,
+  complete,
+  testConnection,
+  handleChat,
+  handleJoin,
+  handleLeave,
+  renderOutreachMessage,
+  processCheckins,
+  startOutreachWatcher,
+  stopOutreachWatcher,
+  conversationActive,
+  openConversation,
+  closeConversation,
+  conversationCommand,
+  listTranscripts,
+  clearTranscripts,
+  pruneTranscripts,
+  pruneOutreach,
+  normalizeBaseUrl,
+  completionMessage,
+  cleanReply,
+  normalizeOutreachMessage,
+};

--- a/src/services/wizard.js
+++ b/src/services/wizard.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const net = require('node:net');
-const dns = require('node:dns').promises;
 const db = require('../db');
+const urlGuard = require('../utils/urlGuard');
 const secrets = require('./secrets');
 const chat = require('./chat');
 const servers = require('./servers');
@@ -27,6 +27,10 @@ const INVOCATION_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,31}$/;
 const MAX_REPLY = 350;
 const HISTORY_MESSAGES = 20;
 const REQUEST_TIMEOUT_MS = 30_000;
+// Cap the response body we buffer from the (admin-configured) LLM endpoint. A
+// well-behaved chat completion is a few KB; anything past this is a broken or
+// hostile endpoint, and reading it unbounded would risk the panel's memory.
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const inflight = new Set();
 const cooldowns = new Map();
 const conversationWindows = new Map();
@@ -117,17 +121,13 @@ function normalizeBaseUrl(raw) {
   if (!['http:', 'https:'].includes(u.protocol)) throw httpError(400, 'The LLM URL must use http or https');
   if (u.username || u.password) throw httpError(400, 'Put credentials in the API key field, not in the URL');
   if (u.search || u.hash) throw httpError(400, 'The LLM base URL cannot contain a query string or fragment');
+  // Block the never-valid literal IPs at save time (link-local/metadata,
+  // multicast, unspecified) while still allowing LAN and loopback for a
+  // self-hosted LLM. Hostnames are re-checked against their resolved address
+  // at fetch time by assertAllowedEndpoint. Shares the panel's SSRF guard.
   const host = u.hostname.replace(/^\[|\]$/g, '');
-  if (net.isIPv4(host)) {
-    const [a, b] = host.split('.').map(Number);
-    if (a === 0 || (a === 169 && b === 254) || a >= 224) {
-      throw httpError(400, 'Link-local, unspecified, multicast, and reserved LLM addresses are not allowed');
-    }
-  } else if (net.isIPv6(host)) {
-    const h = host.toLowerCase();
-    if (h === '::' || h.startsWith('fe80') || h.startsWith('ff')) {
-      throw httpError(400, 'Link-local, unspecified, and multicast LLM addresses are not allowed');
-    }
+  if (net.isIP(host) && urlGuard.isBlockedIp(host, { allowPrivate: true })) {
+    throw httpError(400, 'Link-local, unspecified, multicast, and reserved LLM addresses are not allowed');
   }
   u.pathname = u.pathname.replace(/\/+$/, '');
   return u.toString().replace(/\/$/, '');
@@ -220,31 +220,41 @@ function authHeaders(cfg) {
   return cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {};
 }
 
-function blockedAddress(address) {
-  if (net.isIPv4(address)) {
-    const [a, b] = address.split('.').map(Number);
-    return a === 0 || (a === 169 && b === 254) || a >= 224;
-  }
-  if (net.isIPv6(address)) {
-    const h = address.toLowerCase();
-    return h === '::' || h.startsWith('fe80') || h.startsWith('ff');
-  }
-  return true;
+// Fetch-time SSRF guard. Resolves the host and blocks link-local (incl. cloud
+// metadata), multicast, and unspecified addresses while allowing the LAN and
+// loopback targets a self-hosted LLM needs. Delegates to the panel's shared
+// urlGuard so there is one SSRF implementation, not two that can drift apart.
+async function assertAllowedEndpoint(rawUrl) {
+  await urlGuard.assertPublicUrl(rawUrl, { allowPrivate: true });
 }
 
-async function assertAllowedEndpoint(rawUrl) {
-  const u = new URL(rawUrl);
-  const host = u.hostname.replace(/^\[|\]$/g, '');
-  let addresses = [host];
-  if (!net.isIP(host)) {
-    try {
-      addresses = (await dns.lookup(host, { all: true })).map((r) => r.address);
-    } catch {
-      throw httpError(502, `Could not resolve LLM host ${host}`);
+// Read a JSON body but stop once it passes MAX_RESPONSE_BYTES, so a broken or
+// hostile endpoint cannot make the panel buffer an unbounded response. Returns
+// null on any read/parse problem, which callers already treat as "no body".
+async function readJsonCapped(res) {
+  if (!res.body) return res.json().catch(() => null);
+  const reader = res.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => {});
+        throw httpError(502, 'The LLM server returned an unreasonably large response');
+      }
+      chunks.push(value);
     }
+  } catch (err) {
+    if (err.status) throw err;
+    return null;
   }
-  if (!addresses.length || addresses.some(blockedAddress)) {
-    throw httpError(400, 'The LLM host resolves to a link-local, unspecified, multicast, or reserved address');
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch {
+    return null;
   }
 }
 
@@ -256,7 +266,7 @@ async function fetchJson(url, options = {}) {
   } catch (err) {
     throw httpError(502, `Could not reach the LLM server: ${err.message}`);
   }
-  const body = await res.json().catch(() => null);
+  const body = await readJsonCapped(res);
   if (!res.ok) {
     const detail = body?.error?.message || body?.error || body?.message || `HTTP ${res.status}`;
     throw httpError(502, `LLM server rejected the request: ${String(detail).slice(0, 300)}`);
@@ -570,6 +580,20 @@ async function processCheckins({ now = new Date(), send = sendWizardText } = {})
   return sent;
 }
 
+// Clear expired entries from the in-memory maps so they cannot grow without
+// bound over a long uptime. Every entry here is a short-lived timestamp, so a
+// stale one is safe to drop: conversation windows past their expiry, and chat
+// cooldowns older than five minutes (the actual gate is three seconds).
+function sweepEphemeralState(now = Date.now()) {
+  for (const [key, expiresAt] of conversationWindows) {
+    if (expiresAt <= now) conversationWindows.delete(key);
+  }
+  for (const [key, ts] of cooldowns) {
+    if (now - ts > 300_000) cooldowns.delete(key);
+  }
+  wizardPowers.sweepCooldowns(now);
+}
+
 function startOutreachWatcher({ intervalMs = 30_000 } = {}) {
   if (outreachTimer) return;
   const run = async () => {
@@ -577,6 +601,7 @@ function startOutreachWatcher({ intervalMs = 30_000 } = {}) {
     outreachRunning = true;
     try {
       await processCheckins();
+      sweepEphemeralState();
     } catch (err) {
       console.error('[wizard] outreach watcher:', err.message);
     } finally {
@@ -755,6 +780,7 @@ module.exports = {
   processCheckins,
   startOutreachWatcher,
   stopOutreachWatcher,
+  sweepEphemeralState,
   conversationActive,
   openConversation,
   closeConversation,

--- a/src/services/wizardPowers.js
+++ b/src/services/wizardPowers.js
@@ -470,6 +470,15 @@ async function execute(serverId, player, request, cfg) {
   }
 }
 
+// Drop cooldown entries that can no longer gate anything. The largest cooldown
+// an admin can configure is 3600s, so a timestamp older than that is dead
+// weight. Called on a timer so the map cannot grow forever on a busy server.
+function sweepCooldowns(now = Date.now()) {
+  for (const [key, ts] of cooldowns) {
+    if (now - ts > 3_600_000) cooldowns.delete(key);
+  }
+}
+
 function listAudit(serverId, limit = 100) {
   return listEvents({ serverId, type: 'wizard-power', limit: Math.max(1, Math.min(500, Number(limit) || 100)) });
 }
@@ -494,4 +503,5 @@ module.exports = {
   recordRejection,
   execute,
   listAudit,
+  sweepCooldowns,
 };

--- a/src/services/wizardPowers.js
+++ b/src/services/wizardPowers.js
@@ -1,0 +1,497 @@
+// @ts-nocheck -- OpenAI-compatible tool-call payloads vary between providers.
+'use strict';
+
+const fsp = require('node:fs/promises');
+const nbt = require('prismarine-nbt');
+const httpError = require('../utils/httpError');
+const { PLAYER_NAME_RE } = require('../utils/playerName');
+const { dataPath } = require('../storage/pathGuard');
+const { execCapture, inspectStatus } = require('../docker/containers');
+const { cleanText } = require('../utils/ansi');
+const { recordEvent, listEvents } = require('../events');
+const servers = require('./servers');
+const worlds = require('./worlds');
+const players = require('./players');
+const inventory = require('./inventory');
+const worldControls = require('./worldControls');
+
+const POWER_KEYS = ['heal', 'feed', 'spawn', 'time', 'weather', 'gift'];
+const DEFAULT_FLAGS = Object.freeze(Object.fromEntries(POWER_KEYS.map((key) => [key, true])));
+const DEFAULT_GIFTS = Object.freeze(['minecraft:bread', 'minecraft:torch', 'minecraft:arrow']);
+const ITEM_RE = /^[a-z0-9_.-]+:[a-z0-9_/.-]+$/;
+const cooldowns = new Map();
+
+function uniqueStrings(value) {
+  const seen = new Set();
+  const result = [];
+  for (const raw of Array.isArray(value) ? value : []) {
+    const item = String(raw || '').trim();
+    const key = item.toLowerCase();
+    if (item && !seen.has(key)) {
+      seen.add(key);
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+function normalizeTesters(value) {
+  const names = uniqueStrings(value);
+  if (names.length > 50) throw httpError(400, 'At most 50 Basic users may be configured');
+  if (names.some((name) => !PLAYER_NAME_RE.test(name))) {
+    throw httpError(400, 'Basic users must be valid Minecraft player names');
+  }
+  return names;
+}
+
+function normalizeControllers(value) {
+  const names = uniqueStrings(value);
+  if (names.length > 50) throw httpError(400, 'At most 50 chatbot power controllers may be configured');
+  if (names.some((name) => !PLAYER_NAME_RE.test(name))) {
+    throw httpError(400, 'Power controllers must be valid Minecraft player names');
+  }
+  return names;
+}
+
+function normalizeGiftItems(value) {
+  const items = uniqueStrings(value).map((item) => item.toLowerCase());
+  if (items.length > 100) throw httpError(400, 'At most 100 gift items may be configured');
+  if (items.some((item) => !ITEM_RE.test(item))) {
+    throw httpError(400, 'Gift items must be namespaced Minecraft item IDs, such as minecraft:bread');
+  }
+  return items;
+}
+
+function normalizeFlags(value = {}) {
+  return Object.fromEntries(POWER_KEYS.map((key) => [key, value[key] !== false]));
+}
+
+function isTester(cfg, player) {
+  const wanted = String(player || '').toLowerCase();
+  return cfg.powerTesters.some((name) => name.toLowerCase() === wanted);
+}
+
+function isController(cfg, player) {
+  const wanted = String(player || '').toLowerCase();
+  return (cfg.powerControllers || []).some((name) => name.toLowerCase() === wanted);
+}
+
+function normalizePowerTarget(value) {
+  let target = String(value || '').trim();
+  if (/^@[aeprs]$/i.test(target)) throw httpError(400, 'Minecraft selectors are not valid chatbot targets');
+  if (target.startsWith('@')) target = target.slice(1);
+  if (!PLAYER_NAME_RE.test(target)) throw httpError(400, 'The chatbot requested an invalid target player');
+  return target;
+}
+
+function matchOnlineTarget(value, onlineNames) {
+  const target = normalizePowerTarget(value);
+  const exact = (Array.isArray(onlineNames) ? onlineNames : []).find(
+    (name) => String(name).toLowerCase() === target.toLowerCase()
+  );
+  if (!exact) throw httpError(404, `${target} is not online`);
+  return exact;
+}
+
+const INFORMATION_RE =
+  /\b(?:how (?:do|can|should|would)|recipe|craft(?:ing)?|instructions?|what (?:do|should|can)|where (?:do|can)|explain|teach me|show me how)\b/i;
+
+function powerIntent(prompt) {
+  if (prompt === null || prompt === undefined) return { ...DEFAULT_FLAGS };
+  const text = String(prompt).trim();
+  if (!text || INFORMATION_RE.test(text)) return Object.fromEntries(POWER_KEYS.map((key) => [key, false]));
+  return {
+    heal: /\b(?:heal|cure|revive)\s+me\b|\brestore\s+(?:my\s+)?health\b|\bi(?:'m| am)\s+(?:hurt|dying|low on health)\b/i.test(
+      text
+    ),
+    feed: /\b(?:feed|saturate)\s+me\b|\brestore\s+(?:my\s+)?(?:hunger|food)\b|\bi(?:'m| am)\s+(?:hungry|starving)\b/i.test(
+      text
+    ),
+    spawn: /\b(?:teleport|send|take|return|get)\s+me\s+(?:back\s+)?(?:to\s+)?(?:world\s+)?(?:spawn|home)\b/i.test(text),
+    time: /\b(?:set|change|turn|make)\s+(?:the\s+)?(?:world\s+)?(?:time|it)\s+(?:to\s+)?(?:day|daytime|noon|night|midnight)\b/i.test(
+      text
+    ),
+    weather:
+      /\b(?:make|let)\s+it\s+(?:rain|snow|thunder)\b|\b(?:set|change)\s+(?:the\s+)?weather(?:\s+to)?\s+(?:clear|rain|rainy|thunder|stormy)\b|\b(?:clear|start|stop)\s+(?:the\s+)?(?:rain|weather|storm)\b/i.test(
+        text
+      ),
+    gift: /\b(?:give|grant|hand|bring|spawn|summon)\s+(?:me|us)\b|\b(?:can|could|may|would)\s+(?:you\s+)?(?:give|grant|hand|bring|spawn)\s+me\b|\b(?:can|could|may)\s+i\s+(?:have|get|receive)\b|\bi\s+(?:want|need|would like)\s+(?:an?|some|one|two|three|\d+)\b/i.test(
+      text
+    ),
+  };
+}
+
+const PLAYER_TOKEN = '@?[.*]?[A-Za-z0-9_]{1,16}';
+
+function crossPowerIntent(prompt) {
+  if (prompt === null || prompt === undefined) {
+    return { heal: true, feed: true, teleportToSelf: true, teleportSelfToPlayer: true, gift: true };
+  }
+  const text = String(prompt).trim();
+  if (!text || INFORMATION_RE.test(text)) {
+    return { heal: false, feed: false, teleportToSelf: false, teleportSelfToPlayer: false, gift: false };
+  }
+  return {
+    heal: new RegExp(`\\b(?:heal|cure|revive)\\s+(?!me\\b)${PLAYER_TOKEN}(?:\\b|$)`, 'i').test(text),
+    feed: new RegExp(`\\b(?:feed|saturate)\\s+(?!me\\b)${PLAYER_TOKEN}(?:\\b|$)`, 'i').test(text),
+    teleportToSelf: new RegExp(
+      `\\b(?:teleport|tp|bring|send)\\s+(?!me\\b)${PLAYER_TOKEN}\\s+(?:to\\s+me|here)\\b`,
+      'i'
+    ).test(text),
+    teleportSelfToPlayer: new RegExp(
+      `\\b(?:teleport|tp|send|take)\\s+me\\s+to\\s+(?!(?:spawn|home)\\b)${PLAYER_TOKEN}(?:\\b|$)`,
+      'i'
+    ).test(text),
+    gift: new RegExp(`\\b(?:give|grant|hand)\\s+(?!me\\b|us\\b)${PLAYER_TOKEN}(?:\\b|$)`, 'i').test(text),
+  };
+}
+
+function toolsFor(cfg, player, prompt = null) {
+  const selfAllowed = isTester(cfg, player);
+  const crossAllowed = isController(cfg, player);
+  if (!cfg.powersEnabled || (!selfAllowed && !crossAllowed)) return [];
+  const intent = powerIntent(prompt);
+  const crossIntent = crossPowerIntent(prompt);
+  const tools = [];
+  const add = (name, description, properties = {}, required = []) =>
+    tools.push({
+      type: 'function',
+      function: {
+        name,
+        description,
+        parameters: { type: 'object', properties, required, additionalProperties: false },
+      },
+    });
+  if (selfAllowed && cfg.powerFlags.heal && intent.heal)
+    add('heal_self', 'Restore the requesting player to full health.');
+  if (selfAllowed && cfg.powerFlags.feed && intent.feed)
+    add('feed_self', 'Restore the requesting player to full hunger and saturation.');
+  if (selfAllowed && cfg.powerFlags.spawn && intent.spawn)
+    add('teleport_self_to_spawn', 'Safely teleport the requesting player to world spawn.');
+  if (selfAllowed && cfg.powerFlags.time && intent.time)
+    add(
+      'set_time',
+      'Set this server world time.',
+      { value: { type: 'string', enum: ['day', 'noon', 'night', 'midnight'] } },
+      ['value']
+    );
+  if (selfAllowed && cfg.powerFlags.weather && intent.weather)
+    add('set_weather', 'Set this server weather.', { value: { type: 'string', enum: ['clear', 'rain', 'thunder'] } }, [
+      'value',
+    ]);
+  if (selfAllowed && cfg.powerFlags.gift && intent.gift && cfg.giftItems.length)
+    add(
+      'give_self',
+      'Give an allowlisted item to the requesting player.',
+      {
+        item: { type: 'string', enum: cfg.giftItems },
+        count: { type: 'integer', minimum: 1, maximum: cfg.giftMaxCount },
+      },
+      ['item', 'count']
+    );
+  const target = {
+    type: 'string',
+    pattern: '^[.*]?[A-Za-z0-9_]{1,16}$',
+    description: 'Exact online Minecraft player name without an @ prefix or selector.',
+  };
+  if (crossAllowed && cfg.powerFlags.heal && crossIntent.heal)
+    add('heal_player', 'Restore another exact online player to full health.', { target }, ['target']);
+  if (crossAllowed && cfg.powerFlags.feed && crossIntent.feed)
+    add('feed_player', 'Restore another exact online player to full hunger and saturation.', { target }, ['target']);
+  if (crossAllowed && cfg.powerFlags.spawn && crossIntent.teleportToSelf)
+    add('teleport_player_to_self', 'Teleport another exact online player to the requesting player.', { target }, [
+      'target',
+    ]);
+  if (crossAllowed && cfg.powerFlags.spawn && crossIntent.teleportSelfToPlayer)
+    add('teleport_self_to_player', 'Teleport the requesting player to another exact online player.', { target }, [
+      'target',
+    ]);
+  if (crossAllowed && cfg.powerFlags.gift && crossIntent.gift)
+    add(
+      'give_player',
+      'Give any valid namespaced Minecraft item to another exact online player. Use a vanilla minecraft: ID or the exact mod namespace and item ID.',
+      {
+        target,
+        item: {
+          type: 'string',
+          pattern: ITEM_RE.source,
+          description: 'Exact namespaced item ID, such as minecraft:red_bed or a_mod:item_name.',
+        },
+        count: { type: 'integer', minimum: 1, maximum: cfg.giftMaxCount },
+      },
+      ['target', 'item', 'count']
+    );
+  return tools;
+}
+
+function parseToolCall(message, cfg, player, prompt = null) {
+  const calls = message && Array.isArray(message.tool_calls) ? message.tool_calls : [];
+  if (!calls.length) return null;
+  if (calls.length > 1) {
+    const parsed = calls.map((call) => parseToolCall({ tool_calls: [call] }, cfg, player, prompt));
+    const signatures = new Set(parsed.map((request) => JSON.stringify([request.name, request.args])));
+    if (signatures.size === 1) return parsed[0];
+    throw httpError(400, 'The chatbot requested more than one different power at once');
+  }
+  const call = calls[0];
+  const name = String(call?.function?.name || '');
+  const allowed = new Set(toolsFor(cfg, player, prompt).map((tool) => tool.function.name));
+  if (!allowed.has(name)) throw httpError(403, 'The chatbot requested a disabled or unavailable power');
+  let args;
+  try {
+    args =
+      typeof call.function.arguments === 'string'
+        ? JSON.parse(call.function.arguments || '{}')
+        : call.function.arguments || {};
+  } catch {
+    throw httpError(400, 'The chatbot returned invalid power arguments');
+  }
+  if (!args || Array.isArray(args) || typeof args !== 'object')
+    throw httpError(400, 'The chatbot returned invalid power arguments');
+  const keys = Object.keys(args);
+  if (['heal_self', 'feed_self', 'teleport_self_to_spawn'].includes(name)) {
+    if (keys.length) throw httpError(400, 'This power does not accept arguments');
+  } else if (name === 'set_time') {
+    if (keys.length !== 1 || !['day', 'noon', 'night', 'midnight'].includes(args.value)) {
+      throw httpError(400, 'The chatbot requested an invalid time');
+    }
+  } else if (name === 'set_weather') {
+    if (keys.length !== 1 || !['clear', 'rain', 'thunder'].includes(args.value)) {
+      throw httpError(400, 'The chatbot requested invalid weather');
+    }
+  } else if (name === 'give_self') {
+    const item = String(args.item || '').toLowerCase();
+    const count = Number(args.count);
+    if (
+      keys.some((key) => !['item', 'count'].includes(key)) ||
+      keys.length !== 2 ||
+      !cfg.giftItems.includes(item) ||
+      !Number.isInteger(count) ||
+      count < 1 ||
+      count > cfg.giftMaxCount
+    ) {
+      throw httpError(400, 'The chatbot requested an item or quantity outside the allowlist');
+    }
+    args = { item, count };
+  } else if (['heal_player', 'feed_player', 'teleport_player_to_self', 'teleport_self_to_player'].includes(name)) {
+    const target = normalizePowerTarget(args.target);
+    if (keys.length !== 1 || keys[0] !== 'target' || target.toLowerCase() === String(player).toLowerCase()) {
+      throw httpError(400, 'A cross-player power requires exactly one other player target');
+    }
+    args = { target };
+  } else if (name === 'give_player') {
+    const target = normalizePowerTarget(args.target);
+    const item = String(args.item || '').toLowerCase();
+    const count = Number(args.count);
+    if (
+      keys.some((key) => !['target', 'item', 'count'].includes(key)) ||
+      keys.length !== 3 ||
+      target.toLowerCase() === String(player).toLowerCase() ||
+      !ITEM_RE.test(item) ||
+      !Number.isInteger(count) ||
+      count < 1 ||
+      count > cfg.giftMaxCount
+    ) {
+      throw httpError(400, 'The chatbot requested an invalid target, item ID, or quantity');
+    }
+    args = { target, item, count };
+  }
+  return { id: String(call.id || ''), name, args };
+}
+
+function describe(request, caller = 'the caller') {
+  if (request.name === 'heal_self') return 'restore full health';
+  if (request.name === 'feed_self') return 'restore full hunger';
+  if (request.name === 'teleport_self_to_spawn') return 'teleport to world spawn';
+  if (request.name === 'set_time') return `set the time to ${request.args.value}`;
+  if (request.name === 'set_weather') return `set the weather to ${request.args.value}`;
+  if (request.name === 'give_self') return `give ${request.args.count} × ${request.args.item}`;
+  if (request.name === 'heal_player') return `restore ${request.args.target}'s full health`;
+  if (request.name === 'feed_player') return `restore ${request.args.target}'s full hunger`;
+  if (request.name === 'teleport_player_to_self') return `teleport ${request.args.target} to ${caller}`;
+  if (request.name === 'teleport_self_to_player') return `teleport ${caller} to ${request.args.target}`;
+  return `give ${request.args.target} ${request.args.count} × ${request.args.item}`;
+}
+
+function recordRejection(serverId, player, reason, request = null) {
+  recordEvent({
+    serverId,
+    actor: `wizard:${player}`,
+    type: 'wizard-power',
+    summary: `${player}: Chatbot power rejected`,
+    details: {
+      player,
+      caller: player,
+      target: request?.args?.target || null,
+      power: request?.name || null,
+      arguments: request?.args || null,
+      succeeded: false,
+      rejected: true,
+      reason: String(reason || 'Rejected').slice(0, 300),
+    },
+  });
+}
+
+async function assertRunning(serverId) {
+  const info = await inspectStatus(serverId).catch(() => null);
+  if (!info || !['running', 'unhealthy'].includes(info.status))
+    throw httpError(409, 'The Minecraft server is not running');
+}
+
+async function fixedRcon(serverId, args, player) {
+  await assertRunning(serverId);
+  const out = cleanText(await execCapture(serverId, ['rcon-cli', ...args])).trim();
+  if (/No player was found|No entity was found/i.test(out)) throw httpError(404, `${player} is not online`);
+  if (/Unknown or incomplete command|Incorrect argument|Expected |<--\[HERE\]/i.test(out)) {
+    throw httpError(502, `The server rejected the power: ${out.slice(0, 200)}`);
+  }
+  return out;
+}
+
+async function worldSpawn(serverId) {
+  const server = servers.getServer(serverId);
+  if (!server) throw httpError(404, 'Server not found');
+  const file = dataPath('servers', serverId, worlds.activeLevelName(server), 'level.dat');
+  try {
+    const { parsed } = await nbt.parse(await fsp.readFile(file));
+    const data = nbt.simplify(parsed).Data || nbt.simplify(parsed);
+    const x = Number(data.SpawnX);
+    const z = Number(data.SpawnZ);
+    if (!Number.isFinite(x) || !Number.isFinite(z)) throw new Error('spawn coordinates are missing');
+    return { x, z };
+  } catch (err) {
+    throw httpError(422, `Could not read world spawn: ${err.message}`);
+  }
+}
+
+async function execute(serverId, player, request, cfg) {
+  if (!cfg.powersEnabled || (!isTester(cfg, player) && !isController(cfg, player)))
+    throw httpError(403, 'This player is not allowed to use chatbot powers');
+  if (!PLAYER_NAME_RE.test(String(player))) throw httpError(400, 'Invalid Minecraft player name');
+  try {
+    request = parseToolCall(
+      { tool_calls: [{ function: { name: request?.name, arguments: request?.args || {} } }] },
+      cfg,
+      player
+    );
+  } catch (err) {
+    recordRejection(serverId, player, err.message, request);
+    throw err;
+  }
+  const key = `${serverId}:${String(player).toLowerCase()}`;
+  const remaining = cfg.powerCooldownSec * 1000 - (Date.now() - (cooldowns.get(key) || 0));
+  if (remaining > 0) {
+    const err = httpError(429, `Chatbot powers are recharging for ${Math.ceil(remaining / 1000)} more seconds`);
+    recordRejection(serverId, player, err.message, request);
+    throw err;
+  }
+
+  let action = describe(request, player);
+  let details = {
+    player,
+    caller: player,
+    target: request.args.target || player,
+    power: request.name,
+    arguments: request.args,
+    dryRun: cfg.powersDryRun,
+  };
+  if (cfg.powersDryRun) {
+    recordEvent({
+      serverId,
+      actor: `wizard:${player}`,
+      type: 'wizard-power',
+      summary: `Dry run: ${player} would ${action}`,
+      details,
+    });
+    return { dryRun: true, message: `Dry run only: I would ${action}.` };
+  }
+
+  try {
+    const actor = `wizard:${player}`;
+    if (request.args.target) {
+      request.args.target = matchOnlineTarget(
+        request.args.target,
+        await players.listOnlineNames(serverId, { throwOnError: true })
+      );
+      action = describe(request, player);
+      details = { ...details, target: request.args.target, arguments: request.args };
+    }
+    if (request.name === 'heal_self') {
+      await fixedRcon(serverId, ['effect', 'give', player, 'minecraft:instant_health', '1', '10', 'true'], player);
+    } else if (request.name === 'feed_self')
+      await fixedRcon(serverId, ['effect', 'give', player, 'minecraft:saturation', '1', '10', 'true'], player);
+    else if (request.name === 'teleport_self_to_spawn') {
+      const spawn = await worldSpawn(serverId);
+      await players.withTeleportSlot(serverId, () =>
+        players.tpToCoords(serverId, player, { ...spawn, dimension: 'minecraft:overworld' }, { running: true, actor })
+      );
+    } else if (request.name === 'set_time')
+      await worldControls.runQuick(serverId, `time-${request.args.value}`, { actor });
+    else if (request.name === 'set_weather')
+      await worldControls.runQuick(serverId, `weather-${request.args.value}`, { actor });
+    else if (request.name === 'give_self')
+      await inventory.giveItem(serverId, player, request.args.item, request.args.count, { actor });
+    else if (request.name === 'heal_player')
+      await fixedRcon(
+        serverId,
+        ['effect', 'give', request.args.target, 'minecraft:instant_health', '1', '10', 'true'],
+        request.args.target
+      );
+    else if (request.name === 'feed_player')
+      await fixedRcon(
+        serverId,
+        ['effect', 'give', request.args.target, 'minecraft:saturation', '1', '10', 'true'],
+        request.args.target
+      );
+    else if (request.name === 'teleport_player_to_self')
+      await players.tpToPlayer(serverId, request.args.target, player, { running: true, actor });
+    else if (request.name === 'teleport_self_to_player')
+      await players.tpToPlayer(serverId, player, request.args.target, { running: true, actor });
+    else if (request.name === 'give_player')
+      await inventory.giveItem(serverId, request.args.target, request.args.item, request.args.count, { actor });
+    cooldowns.set(key, Date.now());
+    recordEvent({
+      serverId,
+      actor,
+      type: 'wizard-power',
+      summary: `${player}: ${action}`,
+      details: { ...details, succeeded: true },
+    });
+    return { dryRun: false, message: `It is done: I ${action}.` };
+  } catch (err) {
+    recordEvent({
+      serverId,
+      actor: `wizard:${player}`,
+      type: 'wizard-power',
+      summary: `${player}: ${action} failed`,
+      details: { ...details, succeeded: false, error: String(err.message || err).slice(0, 300) },
+    });
+    throw err;
+  }
+}
+
+function listAudit(serverId, limit = 100) {
+  return listEvents({ serverId, type: 'wizard-power', limit: Math.max(1, Math.min(500, Number(limit) || 100)) });
+}
+
+module.exports = {
+  POWER_KEYS,
+  DEFAULT_FLAGS,
+  DEFAULT_GIFTS,
+  normalizeTesters,
+  normalizeControllers,
+  normalizeGiftItems,
+  normalizeFlags,
+  isTester,
+  isController,
+  normalizePowerTarget,
+  matchOnlineTarget,
+  powerIntent,
+  crossPowerIntent,
+  toolsFor,
+  parseToolCall,
+  describe,
+  recordRejection,
+  execute,
+  listAudit,
+};

--- a/src/services/wizardRecipes.js
+++ b/src/services/wizardRecipes.js
@@ -1,0 +1,187 @@
+// @ts-nocheck -- minecraft-data recipe ingredients have version-dependent shapes.
+'use strict';
+
+const minecraftData = require('minecraft-data');
+
+const RECIPE_WORDS_RE = /\b(?:craft(?:ing)?|recipe)\b/i;
+const HOW_TO_MAKE_RE = /\bhow\b.{0,40}\bmake\b/i;
+const NON_RECIPE_MAKE_RE = /\b(?:rain|weather|day|daytime|night|midnight|thunder|storm)\b/i;
+const ALIASES = Object.freeze({
+  'fishing pole': 'fishing rod',
+  fishingpole: 'fishing rod',
+  'glass block': 'glass',
+  workbench: 'crafting table',
+});
+const PROCESSING_HINTS = Object.freeze({
+  glass: 'Smelt Sand or Red Sand in a furnace to make Glass.',
+});
+
+function normalizeWords(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function dataForVersion(version) {
+  const wanted = String(version || '').trim();
+  if (wanted && wanted.toUpperCase() !== 'LATEST') {
+    try {
+      const exact = minecraftData(wanted);
+      if (exact?.recipes) return exact;
+    } catch {
+      // Fall through to the nearest supported release in the same version line.
+    }
+    const line = /^(\d+\.\d+)/.exec(wanted)?.[1];
+    if (line) {
+      const nearby = minecraftData.versions.pc.find(
+        (entry) => entry.releaseType === 'release' && entry.minecraftVersion.startsWith(`${line}.`)
+      );
+      if (nearby) {
+        const data = minecraftData(nearby.minecraftVersion);
+        if (data?.recipes) return data;
+      }
+    }
+    return null;
+  }
+  const latest = minecraftData.versions.pc.find((entry) => {
+    if (entry.releaseType !== 'release') return false;
+    try {
+      return Boolean(minecraftData(entry.minecraftVersion)?.recipes);
+    } catch {
+      return false;
+    }
+  });
+  return latest ? minecraftData(latest.minecraftVersion) : null;
+}
+
+function phrasePosition(text, phrase) {
+  const match = new RegExp(`\\b${phrase.replace(/ /g, '\\s+')}s?\\b`, 'i').exec(text);
+  return match ? match.index : -1;
+}
+
+function requestedPhrase(text) {
+  const patterns = [/\brecipe\s+(?:for|of)\s+(.+)$/, /\b(?:craft|make)\s+(?:myself\s+)?(?:an?|some)?\s*(.+)$/];
+  const raw = patterns.map((pattern) => pattern.exec(text)?.[1]).find(Boolean);
+  if (!raw) return '';
+  return raw
+    .split(/\b(?:using|with|on|at|in (?:a )?crafting table|in minecraft)\b/)[0]
+    .replace(/^(?:an?|some)\s+/, '')
+    .replace(/\bplease\b/g, '')
+    .trim();
+}
+
+function requestedItem(prompt, data) {
+  let text = normalizeWords(prompt);
+  for (const [alias, canonical] of Object.entries(ALIASES)) text = text.replaceAll(alias, canonical);
+  const target = requestedPhrase(text);
+  const matches = [];
+  for (const item of data?.itemsArray || []) {
+    const names = new Set([normalizeWords(item.name), normalizeWords(item.displayName)]);
+    for (const name of names) {
+      if (!name) continue;
+      if (target && target !== name && target !== `${name}s`) continue;
+      const index = phrasePosition(text, name);
+      if (index >= 0) matches.push({ item, index, length: name.length });
+    }
+  }
+  matches.sort((a, b) => a.index - b.index || b.length - a.length);
+  return matches[0]?.item || null;
+}
+
+function familyChoices(prompt, data) {
+  let text = normalizeWords(prompt);
+  for (const [alias, canonical] of Object.entries(ALIASES)) text = text.replaceAll(alias, canonical);
+  const target = requestedPhrase(text);
+  if (!target) return [];
+  const suffix = ` ${target}`;
+  return (data?.itemsArray || [])
+    .filter((item) => {
+      const name = normalizeWords(item.displayName || item.name);
+      const recipes = data.recipes?.[item.id];
+      return name.endsWith(suffix) && Array.isArray(recipes) && recipes.length > 0;
+    })
+    .map((item) => item.displayName || item.name)
+    .slice(0, 8);
+}
+
+function recipeItem(raw, data) {
+  if (raw === null || raw === undefined) return null;
+  let id = raw;
+  let count = 1;
+  if (Array.isArray(raw)) id = raw[0];
+  else if (typeof raw === 'object') {
+    id = raw.id;
+    count = Math.max(1, Number(raw.count) || 1);
+  }
+  const item = data.items?.[Number(id)] || data.blocks?.[Number(id)];
+  return item ? { id: item.id, name: item.displayName || item.name, count } : null;
+}
+
+function renderRecipe(item, recipe, data) {
+  const shaped = Array.isArray(recipe.inShape);
+  const source = shaped ? recipe.inShape : [recipe.ingredients || []];
+  const height = shaped ? source.length : Math.ceil(source[0].length / (source[0].length <= 4 ? 2 : 3));
+  const width = shaped ? Math.max(...source.map((row) => row.length)) : source[0].length <= 4 ? 2 : 3;
+  const size = Math.max(width, height) <= 2 ? 2 : 3;
+  const flattened = shaped ? null : source[0];
+  const cells = Array.from({ length: size }, (_, row) =>
+    Array.from({ length: size }, (_, col) =>
+      recipeItem(shaped ? source[row]?.[col] : flattened[row * size + col], data)
+    )
+  );
+  const symbols = new Map();
+  const totals = new Map();
+  for (const cell of cells.flat()) {
+    if (!cell) continue;
+    const key = String(cell.id);
+    if (!symbols.has(key)) symbols.set(key, symbols.size + 1);
+    const total = totals.get(key) || { name: cell.name, count: 0 };
+    total.count += cell.count;
+    totals.set(key, total);
+  }
+  const resultCount = Math.max(1, Number(recipe.result?.count) || 1);
+  const title = `${item.displayName || item.name} ×${resultCount} — ${size}×${size}${shaped ? '' : ' shapeless'}`;
+  const rows = cells.map((row) => row.map((cell) => `[${cell ? symbols.get(String(cell.id)) : ' '}]`).join(''));
+  const legend = [...symbols.entries()]
+    .map(([key, symbol]) => {
+      const ingredient = totals.get(key);
+      return `${symbol} ${ingredient.name} ×${ingredient.count}`;
+    })
+    .join(' · ');
+  return [title, ...rows, legend].join('\n');
+}
+
+function recipeReply(prompt, version) {
+  const text = String(prompt || '');
+  const explicit = RECIPE_WORDS_RE.test(text);
+  const howToMake = HOW_TO_MAKE_RE.test(text) && !NON_RECIPE_MAKE_RE.test(text);
+  if (!explicit && !howToMake) return null;
+  const data = dataForVersion(version);
+  const item = data && requestedItem(text, data);
+  const recipes = item && data.recipes?.[item.id];
+  const recipe = Array.isArray(recipes)
+    ? recipes.find((entry) => Array.isArray(entry.inShape)) || recipes.find((entry) => Array.isArray(entry.ingredients))
+    : null;
+  if (!item) {
+    const choices = data ? familyChoices(text, data) : [];
+    if (choices.length) {
+      const last = choices.pop();
+      const list = choices.length ? `${choices.join(', ')}, or ${last}` : last;
+      return `Which kind? Try ${list}.`;
+    }
+    const shownVersion = data?.version?.minecraftVersion || version || 'this Minecraft version';
+    return `I cannot verify that crafting recipe for ${shownVersion}. For modded items, check JEI/REI; for vanilla items, use the recipe book.`;
+  }
+  if (!recipe) {
+    const shownVersion = data.version?.minecraftVersion || version || 'this Minecraft version';
+    const hint = PROCESSING_HINTS[item.name];
+    if (hint) return `${hint} It has no 2×2 or 3×3 crafting-grid recipe in ${shownVersion}.`;
+    return `${item.displayName || item.name} has no 2×2 or 3×3 crafting-grid recipe in ${shownVersion}. It may use a furnace or another workstation, such as a smithing table.`;
+  }
+  return renderRecipe(item, recipe, data);
+}
+
+module.exports = { recipeReply, dataForVersion, requestedItem, familyChoices, renderRecipe };

--- a/src/utils/urlGuard.js
+++ b/src/utils/urlGuard.js
@@ -18,18 +18,24 @@ const httpError = require('./httpError');
 
 const MAX_REDIRECTS = 5;
 
-function isBlockedIpv4(ip) {
+// `allowPrivate` is for callers that legitimately reach a LAN service, such as
+// a self-hosted LLM on the operator's own network. It relaxes the private and
+// loopback ranges but still blocks the addresses that are never a valid target:
+// "this host" (0.0.0.0/8), link-local incl. cloud metadata (169.254.x), and
+// multicast/reserved (>=224). The default caller stays public-only.
+function isBlockedIpv4(ip, { allowPrivate = false } = {}) {
   const p = ip.split('.').map(Number);
   if (p.length !== 4 || p.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true;
   const [a, b] = p;
   if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 169 && b === 254) return true; // link-local (cloud metadata)
+  if (a >= 224) return true; // multicast + reserved
+  if (allowPrivate) return false; // LAN-facing caller keeps loopback + RFC1918 + CGNAT
   if (a === 10) return true; // private
   if (a === 127) return true; // loopback
-  if (a === 169 && b === 254) return true; // link-local (cloud metadata)
   if (a === 172 && b >= 16 && b <= 31) return true; // private
   if (a === 192 && b === 168) return true; // private
   if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
-  if (a >= 224) return true; // multicast + reserved
   return false;
 }
 
@@ -71,16 +77,19 @@ function ipv6MappedIpv4(groups) {
   return [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.');
 }
 
-function isBlockedIpv6(ip) {
+function isBlockedIpv6(ip, { allowPrivate = false } = {}) {
   const s = ip.toLowerCase();
-  if (s === '::' || s === '::1') return true; // unspecified / loopback
-  if (s.startsWith('fe80')) return true; // link-local
-  if (s.startsWith('fc') || s.startsWith('fd')) return true; // unique-local
-  if (s.startsWith('ff')) return true; // multicast
+  if (s === '::') return true; // unspecified (always blocked)
+  if (s.startsWith('fe80')) return true; // link-local (always blocked)
+  if (s.startsWith('ff')) return true; // multicast (always blocked)
   // Catches every IPv4-mapped spelling, not just the textual "::ffff:a.b.c.d"
   // shorthand — e.g. the fully-expanded "0:0:0:0:0:ffff:7f00:1" (=127.0.0.1).
+  // The mapped v4 inherits the same allowPrivate policy.
   const mapped = ipv6MappedIpv4(expandIpv6(s));
-  if (mapped) return isBlockedIpv4(mapped);
+  if (mapped) return isBlockedIpv4(mapped, { allowPrivate });
+  if (allowPrivate) return false; // LAN-facing caller keeps loopback + ULA
+  if (s === '::1') return true; // loopback
+  if (s.startsWith('fc') || s.startsWith('fd')) return true; // unique-local
   return false;
 }
 
@@ -102,16 +111,21 @@ function isAmbiguousNumericHost(host) {
   return labels.length > 0 && labels.every((l) => NUMERIC_LABEL_RE.test(l));
 }
 
-function isBlockedIp(ip) {
+function isBlockedIp(ip, { allowPrivate = false } = {}) {
   // Normalize IPv4-mapped IPv6 (::ffff:1.2.3.4) to its v4 form.
   const v4 = ip.toLowerCase().startsWith('::ffff:') ? ip.slice(ip.lastIndexOf(':') + 1) : ip;
-  if (net.isIPv4(v4)) return isBlockedIpv4(v4);
-  if (net.isIPv6(ip)) return isBlockedIpv6(ip);
+  if (net.isIPv4(v4)) return isBlockedIpv4(v4, { allowPrivate });
+  if (net.isIPv6(ip)) return isBlockedIpv6(ip, { allowPrivate });
   return true; // unknown format — block
 }
 
-/** Throw unless `rawUrl` is an http(s) URL that resolves only to public addresses. */
-async function assertPublicUrl(rawUrl) {
+/**
+ * Throw unless `rawUrl` is an http(s) URL that resolves to an allowed address.
+ * With `{ allowPrivate: true }` the caller opts into LAN/loopback targets (a
+ * self-hosted LLM, say) while link-local, multicast, and unspecified addresses
+ * stay blocked; the default is public-only.
+ */
+async function assertPublicUrl(rawUrl, { allowPrivate = false } = {}) {
   let u;
   try {
     u = new URL(rawUrl);
@@ -136,8 +150,13 @@ async function assertPublicUrl(rawUrl) {
     }
     addrs = results.map((r) => r.address);
   }
-  if (!addrs.length || addrs.some(isBlockedIp)) {
-    throw httpError(400, `Refusing to fetch a private or internal address (${host})`);
+  if (!addrs.length || addrs.some((addr) => isBlockedIp(addr, { allowPrivate }))) {
+    throw httpError(
+      400,
+      allowPrivate
+        ? `Refusing to reach a link-local, multicast, or unspecified address (${host})`
+        : `Refusing to fetch a private or internal address (${host})`
+    );
   }
   return u;
 }

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -130,6 +130,9 @@ function createApp() {
         initial: (s) => (typeof s === 'string' && s ? s[0].toUpperCase() : '?'),
         default: (v, fallback) => (v === undefined || v === null || v === '' ? fallback : v),
         concat: (...args) => args.slice(0, -1).join(''),
+        // Character references avoid Handlebars adding the partial's indentation
+        // after every literal newline inside a <textarea> value.
+        joinLines: (values) => (Array.isArray(values) ? values.join('&#10;') : ''),
         inc: (v) => Number(v) + 1,
         mul: (a, b) => Number(a) * Number(b),
         plural: (n, one, many) => (Number(n) === 1 ? one : many),

--- a/src/web/routes/api.js
+++ b/src/web/routes/api.js
@@ -1048,6 +1048,9 @@ router.use('/servers/:id/chat-commands', require('./chatCommands'));
 // ---- Integrations (Discord, invites, status page) ----
 router.use('/servers/:id/integrations', require('./integrations'));
 
+// ---- Conversational chatbot (legacy /wizard API; configuration + transcripts are admin-only) ----
+router.use('/servers/:id/wizard', requireRoleKeys('admin'), require('./wizard'));
+
 // ---- Analytics & activity timeline ----
 router.use('/servers/:id/analytics', require('./analytics'));
 

--- a/src/web/routes/index.js
+++ b/src/web/routes/index.js
@@ -375,6 +375,11 @@ router.get(
           .inviteInfo(row.id)
           .catch(() => null),
       };
+      // Chatbot endpoint/model/prompt and transcript controls are admin-only.
+      // Do not even hydrate them into a non-admin render context.
+      if (req.user.role === 'admin') {
+        context.integrations.wizard = require('../../services/wizard').getConfig(row.id);
+      }
     } else if (tab === 'players') {
       const playersService = require('../../services/players');
       let online = [];
@@ -427,6 +432,15 @@ router.get(
     res.render('server-detail', context);
   })
 );
+
+router.get('/wizard-transcripts', requireRole('admin'), (req, res) => {
+  const wizard = require('../../services/wizard');
+  res.render('wizard-transcripts', {
+    title: 'Chatbot transcripts',
+    active: 'activity',
+    transcripts: wizard.listTranscripts({ limit: 1000 }),
+  });
+});
 
 router.get('/modpacks', async (req, res) => {
   const withPacks = (res.locals.servers || []).filter((s) => s.pack);

--- a/src/web/routes/wizard.js
+++ b/src/web/routes/wizard.js
@@ -1,0 +1,140 @@
+'use strict';
+
+// Admin-only configuration, diagnostics, and transcript access for the
+// per-server conversational chatbot. The wizard route name is retained for API compatibility.
+
+const express = require('express');
+const { z } = require('zod');
+const asyncHandler = require('../middleware/asyncHandler');
+const { makeJsonErrorHandler } = require('../middleware/jsonErrorHandler');
+const servers = require('../../services/servers');
+const wizard = require('../../services/wizard');
+const wizardPowers = require('../../services/wizardPowers');
+
+const router = express.Router({ mergeParams: true });
+
+function mustGet(req) {
+  const server = servers.getServer(req.params.id);
+  if (!server) {
+    const err = new Error('Server not found');
+    err.status = 404;
+    throw err;
+  }
+  return server;
+}
+
+const connectionSchema = z.object({
+  baseUrl: z.string().trim().min(1).max(500),
+  apiKey: z.string().max(1000).optional(),
+});
+
+router.get('/', (req, res) => {
+  const server = mustGet(req);
+  res.json({ ok: true, wizard: wizard.getConfig(server.id) });
+});
+
+router.post(
+  '/',
+  asyncHandler((req, res) => {
+    const server = mustGet(req);
+    const input = z
+      .object({
+        enabled: z.boolean(),
+        baseUrl: z.string().trim().min(1).max(500),
+        model: z.string().trim().max(200),
+        invocationName: z
+          .string()
+          .trim()
+          .regex(/^[A-Za-z][A-Za-z0-9_-]{0,31}$/)
+          .optional(),
+        apiKey: z.string().max(1000).optional(),
+        clearApiKey: z.boolean().optional(),
+        systemPrompt: z.string().max(12000),
+        retentionDays: z.coerce.number().int().min(0).max(3650),
+        welcomeEnabled: z.boolean().optional(),
+        welcomeMessage: z.string().trim().min(1).max(400).optional(),
+        checkinMinutes: z.coerce.number().int().min(0).max(1440).optional(),
+        checkinMessage: z.string().trim().min(1).max(400).optional(),
+        conversationMinutes: z.coerce.number().int().min(0).max(60).optional(),
+        powersEnabled: z.boolean().optional(),
+        powersDryRun: z.boolean().optional(),
+        powerTesters: z.array(z.string().trim().min(1).max(32)).max(50).optional(),
+        powerControllers: z.array(z.string().trim().min(1).max(32)).max(50).optional(),
+        powerFlags: z
+          .object({
+            heal: z.boolean(),
+            feed: z.boolean(),
+            spawn: z.boolean(),
+            time: z.boolean(),
+            weather: z.boolean(),
+            gift: z.boolean(),
+          })
+          .optional(),
+        giftItems: z.array(z.string().trim().min(1).max(200)).max(100).optional(),
+        giftMaxCount: z.coerce.number().int().min(1).max(16).optional(),
+        powerCooldownSec: z.coerce.number().int().min(3).max(3600).optional(),
+      })
+      .parse(req.body);
+    res.json({
+      ok: true,
+      wizard: wizard.saveConfig(server.id, input, { actor: req.user.username }),
+    });
+  })
+);
+
+router.post(
+  '/models',
+  asyncHandler(async (req, res) => {
+    const server = mustGet(req);
+    const input = connectionSchema.parse(req.body);
+    const stored = wizard.getConfig(server.id, { includeSecret: true });
+    const models = await wizard.listModels(server.id, {
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey && input.apiKey.trim() ? input.apiKey.trim() : stored.apiKey,
+    });
+    res.json({ ok: true, models });
+  })
+);
+
+router.post(
+  '/test',
+  asyncHandler(async (req, res) => {
+    const server = mustGet(req);
+    const input = z
+      .object({
+        baseUrl: z.string().trim().min(1).max(500),
+        model: z.string().trim().min(1).max(200),
+        apiKey: z.string().max(1000).optional(),
+      })
+      .parse(req.body);
+    const stored = wizard.getConfig(server.id, { includeSecret: true });
+    const reply = await wizard.testConnection(server.id, {
+      baseUrl: input.baseUrl,
+      model: input.model,
+      apiKey: input.apiKey && input.apiKey.trim() ? input.apiKey.trim() : stored.apiKey,
+    });
+    res.json({ ok: true, reply });
+  })
+);
+
+router.get('/transcripts', (req, res) => {
+  const server = mustGet(req);
+  const limit = z.coerce.number().int().min(1).max(2000).default(250).parse(req.query.limit);
+  res.json({ ok: true, transcripts: wizard.listTranscripts({ serverId: server.id, limit }) });
+});
+
+router.delete('/transcripts', (req, res) => {
+  const server = mustGet(req);
+  const result = wizard.clearTranscripts(server.id);
+  res.json({ ok: true, deleted: Number(result.changes) || 0 });
+});
+
+router.get('/powers/audit', (req, res) => {
+  const server = mustGet(req);
+  const limit = z.coerce.number().int().min(1).max(500).default(100).parse(req.query.limit);
+  res.json({ ok: true, events: wizardPowers.listAudit(server.id, limit) });
+});
+
+router.use(makeJsonErrorHandler('wizard'));
+
+module.exports = router;

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -37,3 +37,13 @@ test('normalizeTarget accepts Bedrock (Geyser/Floodgate) names with a leading . 
   assert.equal(chat.normalizeTarget('.Steve'), '.Steve');
   assert.equal(chat.normalizeTarget('*Alex'), '*Alex');
 });
+
+test('normalizeMessageText preserves deliberate recipe rows only when requested', () => {
+  assert.equal(chat.normalizeMessageText('one\ntwo'), 'one two');
+  assert.equal(chat.normalizeMessageText('one\r\n\r\n\r\ntwo', true), 'one\n\ntwo');
+});
+
+test('deliveryLines turns recipe rows into separate tellraw payloads only when requested', () => {
+  assert.deepEqual(chat.deliveryLines('title\n[1][ ][1]\n[1][ ][1]', true), ['title', '[1][ ][1]', '[1][ ][1]']);
+  assert.deepEqual(chat.deliveryLines('ordinary\nmessage'), ['ordinary\nmessage']);
+});

--- a/test/urlGuard.test.js
+++ b/test/urlGuard.test.js
@@ -93,3 +93,38 @@ test('assertPublicUrl accepts a public literal IP', async () => {
   const u = await assertPublicUrl('https://8.8.8.8/');
   assert.equal(u.hostname, '8.8.8.8');
 });
+
+// The allowPrivate option is what the self-hosted-LLM guard (wizard.js) relies
+// on: LAN and loopback are reachable, but the addresses that are never a valid
+// target stay blocked so it cannot be turned into a metadata-server SSRF.
+test('isBlockedIp with allowPrivate keeps LAN and loopback but still blocks the dangerous ranges', () => {
+  for (const ip of [
+    '127.0.0.1',
+    '10.0.0.25',
+    '192.168.1.50',
+    '172.16.5.5',
+    '100.64.0.1',
+    '::1',
+    'fc00::1',
+    'fd12::1',
+  ]) {
+    assert.equal(isBlockedIp(ip, { allowPrivate: true }), false, `${ip} should be allowed on a LAN`);
+  }
+  for (const ip of ['0.0.0.0', '169.254.169.254', '224.0.0.1', '239.255.255.250', '::', 'fe80::1', 'ff02::1']) {
+    assert.equal(isBlockedIp(ip, { allowPrivate: true }), true, `${ip} must stay blocked even on a LAN`);
+  }
+  // An IPv4-mapped IPv6 spelling of the cloud-metadata address must not sneak past.
+  assert.equal(isBlockedIp('::ffff:169.254.169.254', { allowPrivate: true }), true);
+  assert.equal(isBlockedIp('0:0:0:0:0:ffff:169.254.169.254', { allowPrivate: true }), true);
+});
+
+test('assertPublicUrl with allowPrivate reaches a LAN host but rejects the metadata address', async () => {
+  const lan = await assertPublicUrl('http://192.168.1.50:11434/', { allowPrivate: true });
+  assert.equal(lan.hostname, '192.168.1.50');
+  const loopback = await assertPublicUrl('http://127.0.0.1:11434/', { allowPrivate: true });
+  assert.equal(loopback.hostname, '127.0.0.1');
+  await assert.rejects(
+    () => assertPublicUrl('http://169.254.169.254/latest/meta-data/', { allowPrivate: true }),
+    /link-local, multicast, or unspecified/
+  );
+});

--- a/test/wizard.test.js
+++ b/test/wizard.test.js
@@ -559,3 +559,55 @@ test('link-local metadata endpoints are rejected while LAN endpoints are accepte
   assert.throws(() => wizard.normalizeBaseUrl('http://169.254.169.254/latest'), /not allowed/);
   assert.equal(wizard.normalizeBaseUrl('http://10.0.0.25:11434/'), 'http://10.0.0.25:11434');
 });
+
+test('a player in neither power list gets no tools and cannot invoke a hallucinated one', () => {
+  const cfg = {
+    powersEnabled: true,
+    powerTesters: ['Gleep52'],
+    powerControllers: [],
+    powerFlags: { heal: true, feed: true, spawn: true, time: true, weather: true, gift: true },
+    giftItems: ['minecraft:bread'],
+    giftMaxCount: 8,
+    powerCooldownSec: 30,
+  };
+  // An outsider is exposed nothing, no matter how power-shaped their message is.
+  assert.deepEqual(wizardPowers.toolsFor(cfg, 'Outsider', 'heal me and give me diamonds'), []);
+  // Even if the model returns a tool call anyway, the server rejects it before
+  // anything runs, because the allowed set for this player is empty.
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        { tool_calls: [{ function: { name: 'heal_self', arguments: '{}' } }] },
+        cfg,
+        'Outsider'
+      ),
+    /disabled or unavailable/
+  );
+});
+
+test('an oversized LLM response is refused instead of buffered without limit', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response('x'.repeat(3 * 1024 * 1024), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  try {
+    await assert.rejects(
+      wizard.listModels(serverId, { baseUrl: 'http://127.0.0.1:11434', apiKey: '' }),
+      /unreasonably large/
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('sweepEphemeralState drops expired conversation windows and keeps live ones', () => {
+  const t0 = 2_000_000_000_000;
+  // An expired window is pruned even though we query it at a time it would still
+  // have been active, proving the sweep removed it rather than a lazy read.
+  wizard.openConversation('srv_sweep', 'Zoe', 5, t0);
+  wizard.sweepEphemeralState(t0 + 300_001);
+  assert.equal(wizard.conversationActive('srv_sweep', 'Zoe', t0 + 1), false);
+  // A window that has not expired survives the sweep.
+  wizard.openConversation('srv_sweep', 'Max', 5, t0);
+  wizard.sweepEphemeralState(t0 + 1);
+  assert.equal(wizard.conversationActive('srv_sweep', 'Max', t0 + 2), true);
+});

--- a/test/wizard.test.js
+++ b/test/wizard.test.js
@@ -1,0 +1,561 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const app = require('./helpers/app');
+const db = require('../src/db');
+const auth = require('../src/services/auth');
+const wizard = require('../src/services/wizard');
+const wizardPowers = require('../src/services/wizardPowers');
+
+let adminCookie;
+let operatorCookie;
+let viewerCookie;
+const serverId = 'srv_wizard01';
+
+async function login(username, password, role) {
+  auth.createUser({ username, password, role }, { actor: 'test' });
+  const r = await app.req('POST', '/login', { body: { username, password } });
+  return (r.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+}
+
+test.before(async () => {
+  await app.start();
+  adminCookie = await app.adminCookie();
+  operatorCookie = await login('wizardop', 'operatorpass123', 'operator');
+  viewerCookie = await login('wizardviewer', 'viewerpass123', 'viewer');
+  app.seedServer(serverId);
+});
+
+test.after(async () => {
+  await app.stop();
+});
+
+test('chatbot configuration and transcripts are admin-only', async () => {
+  for (const cookie of [viewerCookie, operatorCookie]) {
+    assert.equal((await app.req('GET', `/api/servers/${serverId}/wizard`, { cookie })).status, 403);
+    assert.equal((await app.req('GET', `/api/servers/${serverId}/wizard/transcripts`, { cookie })).status, 403);
+    assert.equal((await app.req('GET', `/api/servers/${serverId}/wizard/powers/audit`, { cookie })).status, 403);
+    assert.equal((await app.req('GET', '/wizard-transcripts', { cookie })).status, 403);
+  }
+  assert.equal((await app.req('GET', `/api/servers/${serverId}/wizard`, { cookie: adminCookie })).status, 200);
+  assert.equal((await app.req('GET', '/wizard-transcripts', { cookie: adminCookie })).status, 200);
+
+  const adminPage = await app.req('GET', `/servers/${serverId}/integrations`, { cookie: adminCookie });
+  const operatorPage = await app.req('GET', `/servers/${serverId}/integrations`, { cookie: operatorCookie });
+  assert.match(adminPage.text, /Chatbot settings/);
+  assert.match(adminPage.text, /Basic users/);
+  assert.match(adminPage.text, /Refresh this server's transcripts/);
+  assert.match(adminPage.text, /Refresh power audit/);
+  assert.match(adminPage.text, /Player outreach/);
+  assert.match(adminPage.text, /@wizard chat/);
+  assert.match(adminPage.text, /Power controllers/);
+  const giftTextarea = /id="ig-wz-gifts">([\s\S]*?)<\/textarea>/.exec(adminPage.text);
+  assert.ok(giftTextarea);
+  assert.deepEqual(giftTextarea[1].replaceAll('&#10;', '\n').split('\n'), [
+    'minecraft:bread',
+    'minecraft:torch',
+    'minecraft:arrow',
+  ]);
+  assert.doesNotMatch(operatorPage.text, /Chatbot settings/);
+});
+
+test('per-server config encrypts the API key and defaults retention to seven days', async () => {
+  const initial = await app.req('GET', `/api/servers/${serverId}/wizard`, { cookie: adminCookie });
+  assert.equal(initial.json.wizard.retentionDays, 7);
+  assert.equal(initial.json.wizard.invocationName, 'wizard');
+  assert.match(initial.json.wizard.systemPrompt, /ancient, playful wizard/);
+  assert.equal(initial.json.wizard.welcomeEnabled, true);
+  assert.equal(initial.json.wizard.checkinMinutes, 15);
+  assert.equal(initial.json.wizard.conversationMinutes, 5);
+  assert.equal(initial.json.wizard.powersEnabled, false);
+  assert.equal(initial.json.wizard.powersDryRun, true);
+  assert.deepEqual(initial.json.wizard.powerControllers, []);
+
+  const saved = await app.req('POST', `/api/servers/${serverId}/wizard`, {
+    cookie: adminCookie,
+    body: {
+      enabled: true,
+      baseUrl: 'http://192.168.1.50:11434',
+      model: 'llama3.2:latest',
+      invocationName: 'bubba',
+      apiKey: 'not-plaintext-in-db',
+      systemPrompt: 'You are the test wizard.',
+      retentionDays: 14,
+      welcomeEnabled: true,
+      welcomeMessage: 'Greetings {player}; I am {wizard}. Call {mention}.',
+      checkinMinutes: 20,
+      checkinMessage: '{player}, checking in after {minutes} minutes.',
+      conversationMinutes: 7,
+    },
+  });
+  assert.equal(saved.status, 200);
+  assert.equal(saved.json.wizard.hasApiKey, true);
+  assert.equal(Object.hasOwn(saved.json.wizard, 'apiKey'), false);
+  const stored = db.get('SELECT * FROM wizard_configs WHERE server_id = ?', serverId);
+  assert.notEqual(stored.api_key_cipher, 'not-plaintext-in-db');
+  assert.equal(stored.invocation_name, 'bubba');
+  assert.equal(stored.checkin_minutes, 20);
+  assert.equal(saved.json.wizard.conversationMinutes, 7);
+  assert.equal(wizard.getConfig(serverId, { includeSecret: true }).apiKey, 'not-plaintext-in-db');
+});
+
+test('power configuration is per-server, bounded, and admin-only', async () => {
+  const saved = await app.req('POST', `/api/servers/${serverId}/wizard`, {
+    cookie: adminCookie,
+    body: {
+      enabled: true,
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'qwen:test',
+      invocationName: 'bubba',
+      systemPrompt: 'Test wizard',
+      retentionDays: 7,
+      powersEnabled: true,
+      powersDryRun: true,
+      powerTesters: ['Gleep52'],
+      powerControllers: ['Gleep52'],
+      powerFlags: { heal: true, feed: true, spawn: true, time: false, weather: true, gift: true },
+      giftItems: ['minecraft:bread', 'minecraft:torch'],
+      giftMaxCount: 8,
+      powerCooldownSec: 45,
+    },
+  });
+  assert.equal(saved.status, 200);
+  assert.deepEqual(saved.json.wizard.powerTesters, ['Gleep52']);
+  assert.deepEqual(saved.json.wizard.powerControllers, ['Gleep52']);
+  assert.deepEqual(saved.json.wizard.giftItems, ['minecraft:bread', 'minecraft:torch']);
+  assert.equal(saved.json.wizard.giftMaxCount, 8);
+  assert.equal(saved.json.wizard.powerFlags.time, false);
+
+  const excessive = await app.req('POST', `/api/servers/${serverId}/wizard`, {
+    cookie: adminCookie,
+    body: {
+      enabled: false,
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'qwen:test',
+      systemPrompt: 'Test',
+      retentionDays: 7,
+      giftMaxCount: 17,
+    },
+  });
+  assert.equal(excessive.status, 400);
+});
+
+test('power tools can only affect the caller and reject injected arguments', () => {
+  const cfg = wizard.getConfig(serverId);
+  const selfOnlyCfg = { ...cfg, powerControllers: [] };
+  const tools = wizardPowers.toolsFor(selfOnlyCfg, 'Gleep52');
+  assert.ok(tools.length > 0);
+  assert.equal(wizardPowers.toolsFor(selfOnlyCfg, 'SomeoneElse').length, 0);
+  const serialized = JSON.stringify(tools);
+  assert.doesNotMatch(serialized, /target|selector|command|rcon/i);
+
+  const gift = wizardPowers.parseToolCall(
+    {
+      tool_calls: [
+        {
+          id: 'call-1',
+          function: { name: 'give_self', arguments: '{"item":"minecraft:bread","count":2}' },
+        },
+      ],
+    },
+    cfg,
+    'Gleep52'
+  );
+  assert.deepEqual(gift.args, { item: 'minecraft:bread', count: 2 });
+  const duplicate = wizardPowers.parseToolCall(
+    {
+      tool_calls: [
+        { function: { name: 'give_self', arguments: '{"item":"minecraft:bread","count":2}' } },
+        { function: { name: 'give_self', arguments: { item: 'minecraft:bread', count: 2 } } },
+      ],
+    },
+    cfg,
+    'Gleep52'
+  );
+  assert.deepEqual(duplicate.args, { item: 'minecraft:bread', count: 2 });
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        {
+          tool_calls: [
+            { function: { name: 'heal_self', arguments: '{}' } },
+            { function: { name: 'give_self', arguments: '{"item":"minecraft:bread","count":1}' } },
+          ],
+        },
+        cfg,
+        'Gleep52'
+      ),
+    /more than one different power/
+  );
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        {
+          tool_calls: [
+            {
+              function: {
+                name: 'give_self',
+                arguments: '{"item":"minecraft:bread","count":2,"target":"NotTheCaller"}',
+              },
+            },
+          ],
+        },
+        cfg,
+        'Gleep52'
+      ),
+    /outside the allowlist/
+  );
+});
+
+test('power controllers receive only bounded cross-player tools with exact targets', () => {
+  const cfg = wizard.getConfig(serverId);
+  const names = (prompt, override = cfg) =>
+    wizardPowers.toolsFor(override, 'Gleep52', prompt).map((tool) => tool.function.name);
+  assert.deepEqual(names('teleport @PlayerA to me'), ['teleport_player_to_self']);
+  assert.deepEqual(names('teleport me to PlayerA'), ['teleport_self_to_player']);
+  assert.deepEqual(names('heal PlayerA'), ['heal_player']);
+  assert.deepEqual(names('feed PlayerA'), ['feed_player']);
+  assert.deepEqual(names('give PlayerA four torches'), ['give_player']);
+
+  const controllerOnly = { ...cfg, powerTesters: [] };
+  assert.deepEqual(names('heal me', controllerOnly), []);
+  assert.deepEqual(names('heal PlayerA', controllerOnly), ['heal_player']);
+  assert.deepEqual(names('give PlayerA a red bed', { ...controllerOnly, giftItems: [] }), ['give_player']);
+
+  const request = wizardPowers.parseToolCall(
+    { tool_calls: [{ function: { name: 'teleport_player_to_self', arguments: '{"target":"@PlayerA"}' } }] },
+    cfg,
+    'Gleep52',
+    'teleport @PlayerA to me'
+  );
+  assert.deepEqual(request.args, { target: 'PlayerA' });
+  const gift = wizardPowers.parseToolCall(
+    {
+      tool_calls: [
+        {
+          function: {
+            name: 'give_player',
+            arguments: '{"target":"PlayerA","item":"minecraft:torch","count":4}',
+          },
+        },
+      ],
+    },
+    cfg,
+    'Gleep52',
+    'give PlayerA four torches'
+  );
+  assert.deepEqual(gift.args, { target: 'PlayerA', item: 'minecraft:torch', count: 4 });
+  const unrestrictedGift = wizardPowers.parseToolCall(
+    {
+      tool_calls: [
+        {
+          function: {
+            name: 'give_player',
+            arguments: '{"target":"PlayerA","item":"minecraft:diamond","count":4}',
+          },
+        },
+      ],
+    },
+    cfg,
+    'Gleep52',
+    'give PlayerA four diamonds'
+  );
+  assert.deepEqual(unrestrictedGift.args, { target: 'PlayerA', item: 'minecraft:diamond', count: 4 });
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        {
+          tool_calls: [
+            {
+              function: {
+                name: 'give_player',
+                arguments: '{"target":"PlayerA","item":"minecraft:diamond; op Gleep52","count":1}',
+              },
+            },
+          ],
+        },
+        cfg,
+        'Gleep52',
+        'give PlayerA a diamond'
+      ),
+    /invalid target, item ID, or quantity/
+  );
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        { tool_calls: [{ function: { name: 'teleport_player_to_self', arguments: '{"target":"@a"}' } }] },
+        cfg,
+        'Gleep52',
+        'teleport @a to me'
+      ),
+    /selectors/
+  );
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        { tool_calls: [{ function: { name: 'heal_player', arguments: '{"target":"Gleep52"}' } }] },
+        cfg,
+        'Gleep52',
+        'heal Gleep52'
+      ),
+    /one other player/
+  );
+  assert.equal(wizardPowers.matchOnlineTarget('playera', ['Gleep52', 'PlayerA']), 'PlayerA');
+  assert.throws(() => wizardPowers.matchOnlineTarget('PlayerB', ['PlayerA']), /not online/);
+});
+
+test('power intent requires an explicit action and keeps recipe questions conversational', () => {
+  const cfg = wizard.getConfig(serverId);
+  const names = (prompt) => wizardPowers.toolsFor(cfg, 'Gleep52', prompt).map((tool) => tool.function.name);
+  assert.deepEqual(names('how do I craft myself a fishing pole using a crafting table?'), []);
+  assert.deepEqual(names('what is the recipe for a torch?'), []);
+  assert.deepEqual(names('how do I make it rain in Minecraft?'), []);
+  assert.deepEqual(names('give me one torch please'), ['give_self']);
+  assert.deepEqual(names('can I have a light?'), ['give_self']);
+  assert.deepEqual(names('make it rain please'), ['set_weather']);
+  assert.deepEqual(names('teleport me home'), ['teleport_self_to_spawn']);
+  assert.deepEqual(names('teleport PlayerA to me'), ['teleport_player_to_self']);
+
+  assert.throws(
+    () =>
+      wizardPowers.parseToolCall(
+        {
+          tool_calls: [{ function: { name: 'give_self', arguments: '{"item":"minecraft:torch","count":1}' } }],
+        },
+        cfg,
+        'Gleep52',
+        'how do I craft a torch?'
+      ),
+    /disabled or unavailable/
+  );
+});
+
+test('eligible model requests receive only structured tools and unsupported models fall back to chat', async () => {
+  const originalFetch = global.fetch;
+  const requests = [];
+  global.fetch = async (_url, options) => {
+    const body = JSON.parse(options.body);
+    requests.push(body);
+    if (requests.length === 1) {
+      return new Response(JSON.stringify({ error: { message: 'tools are not supported' } }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(
+      JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'Only conversation.' } }] }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  };
+  try {
+    const result = await wizard.completionMessage(serverId, 'Gleep52', 'Give me two pieces of bread.', {
+      allowPowers: true,
+    });
+    assert.equal(result.message.content, 'Only conversation.');
+    assert.ok(requests[0].tools.length > 0);
+    assert.equal(Object.hasOwn(requests[1], 'tools'), false);
+    assert.match(requests[1].messages[0].content, /No gameplay tools are available/);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('dry-run powers write a complete audit event without executing RCON', async () => {
+  const cfg = wizard.getConfig(serverId);
+  await assert.rejects(
+    wizardPowers.execute(serverId, 'Gleep52', { name: 'set_time', args: { value: 'day' } }, cfg),
+    /disabled or unavailable/
+  );
+  const result = await wizardPowers.execute(serverId, 'Gleep52', { name: 'heal_self', args: {} }, cfg);
+  assert.equal(result.dryRun, true);
+  const immediateSecondDryRun = await wizardPowers.execute(serverId, 'Gleep52', { name: 'heal_self', args: {} }, cfg);
+  assert.equal(immediateSecondDryRun.dryRun, true);
+  const crossPlayer = await wizardPowers.execute(
+    serverId,
+    'Gleep52',
+    { name: 'teleport_player_to_self', args: { target: 'PlayerA' } },
+    cfg
+  );
+  assert.match(crossPlayer.message, /teleport PlayerA to Gleep52/);
+  const audit = wizardPowers.listAudit(serverId, 10);
+  assert.match(audit[0].summary, /Dry run: Gleep52 would teleport PlayerA to Gleep52/);
+  assert.equal(audit[0].details.power, 'teleport_player_to_self');
+  assert.equal(audit[0].details.caller, 'Gleep52');
+  assert.equal(audit[0].details.target, 'PlayerA');
+  assert.equal(audit[0].details.dryRun, true);
+});
+
+test('model discovery supports OpenAI-compatible model lists and free-text trigger parsing', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async (url) => {
+    assert.equal(String(url), 'http://127.0.0.1:11434/v1/models');
+    return new Response(JSON.stringify({ data: [{ id: 'qwen:test' }, { id: 'llama:test' }] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  try {
+    assert.deepEqual(await wizard.listModels(serverId, { baseUrl: 'http://127.0.0.1:11434', apiKey: '' }), [
+      'llama:test',
+      'qwen:test',
+    ]);
+  } finally {
+    global.fetch = originalFetch;
+  }
+  assert.equal(wizard.TRIGGER_RE.test('ordinary player chat'), false);
+  assert.equal(wizard.TRIGGER_RE.test('@wizard what mysteries await?'), true);
+  assert.equal(wizard.invocationPattern('bubba').test('@wizard what mysteries await?'), false);
+  assert.equal(wizard.invocationPattern('bubba').test('@BUBBA what mysteries await?'), true);
+  assert.equal(wizard.assistantLabel('bubba'), 'Bubba');
+});
+
+test('conversational replies unwrap story envelopes and never end mid-word', () => {
+  assert.equal(
+    wizard.cleanReply('{"name":"tell_a_story","parameters":{"story":"Finley found a pearl and swam home."}}'),
+    'Finley found a pearl and swam home.'
+  );
+  const long = wizard.cleanReply('Finley crossed the bright reef. '.repeat(30));
+  assert.ok(long.length <= 350);
+  assert.match(long, /\. …$/);
+  assert.throws(() => wizard.cleanReply('{"name":"tell_a_story","parameters":{"length":300}}'), /tool-shaped response/);
+});
+
+test('invocation names reject ambiguous or unsafe values', async () => {
+  for (const invocationName of ['two words', '@wizard', '9lives', 'wizard!']) {
+    const res = await app.req('POST', `/api/servers/${serverId}/wizard`, {
+      cookie: adminCookie,
+      body: {
+        enabled: false,
+        baseUrl: 'http://127.0.0.1:11434',
+        model: 'qwen:test',
+        invocationName,
+        systemPrompt: 'Test',
+        retentionDays: 7,
+      },
+    });
+    assert.equal(res.status, 400, invocationName);
+  }
+});
+
+test('join greetings and playtime check-ins send once per player session', async () => {
+  wizard.saveConfig(serverId, {
+    enabled: true,
+    baseUrl: 'http://127.0.0.1:11434',
+    model: 'qwen:test',
+    invocationName: 'bubba',
+    systemPrompt: 'Test',
+    retentionDays: 7,
+    welcomeEnabled: true,
+    welcomeMessage: 'Welcome {player}; I am {chatbot}. Use {mention}.',
+    checkinMinutes: 15,
+    checkinMessage: '{player}, it has been {minutes} minutes. Need help from {wizard}?',
+    conversationMinutes: 5,
+  });
+  const sent = [];
+  const send = async (id, cfg, target, text) => sent.push({ id, cfg, target, text });
+  const joinedAt = '2026-08-28T12:00:00.000Z';
+  assert.equal(await wizard.handleJoin(serverId, 'Gleep52', joinedAt, { send }), true);
+  assert.equal(await wizard.handleJoin(serverId, 'Gleep52', joinedAt, { send }), false);
+  assert.deepEqual(sent[0], {
+    id: serverId,
+    cfg: wizard.getConfig(serverId),
+    target: '@a',
+    text: 'Welcome Gleep52; I am Bubba. Use @bubba.',
+  });
+  assert.equal(
+    wizard.renderOutreachMessage('Legacy name: {wizard}.', wizard.getConfig(serverId), 'Gleep52'),
+    'Legacy name: Bubba.'
+  );
+
+  db.run('INSERT INTO player_sessions (server_id, player, started_at) VALUES (?, ?, ?)', serverId, 'Gleep52', joinedAt);
+  const now = new Date('2026-08-28T12:16:00.000Z');
+  assert.equal(await wizard.processCheckins({ now, send }), 1);
+  assert.equal(await wizard.processCheckins({ now, send }), 0);
+  assert.equal(sent[1].target, 'Gleep52');
+  assert.equal(sent[1].text, 'Gleep52, it has been 15 minutes. Need help from Bubba?');
+  db.run(
+    'UPDATE player_sessions SET ended_at = ? WHERE server_id = ? AND ended_at IS NULL',
+    now.toISOString(),
+    serverId
+  );
+});
+
+test('outreach timing is bounded by the admin-only API', async () => {
+  const invalid = await app.req('POST', `/api/servers/${serverId}/wizard`, {
+    cookie: adminCookie,
+    body: {
+      enabled: true,
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'qwen:test',
+      systemPrompt: 'Test',
+      retentionDays: 7,
+      checkinMinutes: 1441,
+      conversationMinutes: 61,
+    },
+  });
+  assert.equal(invalid.status, 400);
+});
+
+test('conversation mode is explicitly opened, expires, and closes when the player leaves', async () => {
+  assert.equal(wizard.conversationCommand('chat'), 'open');
+  assert.equal(wizard.conversationCommand("let's talk"), 'open');
+  assert.equal(wizard.conversationCommand('bye'), 'close');
+  assert.equal(wizard.conversationCommand('how are you?'), null);
+  const start = Date.parse('2026-08-28T12:00:00.000Z');
+  assert.equal(wizard.conversationActive(serverId, 'Gleep52', start), false);
+  wizard.openConversation(serverId, 'Gleep52', 5, start);
+  assert.equal(wizard.conversationActive(serverId, 'Gleep52', start + 299_999), true);
+  assert.equal(wizard.conversationActive(serverId, 'Gleep52', start + 300_000), false);
+  wizard.openConversation(serverId, 'Gleep52', 5, start);
+  wizard.handleLeave(serverId, 'Gleep52');
+  assert.equal(wizard.conversationActive(serverId, 'Gleep52', start + 1), false);
+});
+
+test('retention pruning preserves recent rows and removes expired rows', () => {
+  wizard.saveConfig(serverId, {
+    enabled: false,
+    baseUrl: 'http://127.0.0.1:11434',
+    model: 'qwen:test',
+    systemPrompt: 'Test',
+    retentionDays: 7,
+  });
+  db.run(
+    "INSERT INTO wizard_transcripts (server_id, server_name, player, role, content, created_at) VALUES (?, 'Test', 'Alex', 'user', 'old', datetime('now', '-8 days'))",
+    serverId
+  );
+  db.run(
+    "INSERT INTO wizard_transcripts (server_id, server_name, player, role, content) VALUES (?, 'Test', 'Alex', 'assistant', 'recent')",
+    serverId
+  );
+  wizard.pruneTranscripts(serverId);
+  const rows = wizard.listTranscripts({ serverId });
+  assert.equal(
+    rows.some((r) => r.content === 'old'),
+    false
+  );
+  assert.equal(
+    rows.some((r) => r.content === 'recent'),
+    true
+  );
+  assert.equal(rows.find((r) => r.content === 'recent').speaker, 'Bubba');
+});
+
+test('transcripts remain available after the server is soft-deleted', () => {
+  db.run("UPDATE servers SET deleted_at = datetime('now') WHERE id = ?", serverId);
+  const rows = wizard.listTranscripts({ serverId });
+  assert.equal(
+    rows.some((r) => r.content === 'recent'),
+    true
+  );
+  db.run('UPDATE servers SET deleted_at = NULL WHERE id = ?', serverId);
+});
+
+test('link-local metadata endpoints are rejected while LAN endpoints are accepted', () => {
+  assert.throws(() => wizard.normalizeBaseUrl('http://169.254.169.254/latest'), /not allowed/);
+  assert.equal(wizard.normalizeBaseUrl('http://10.0.0.25:11434/'), 'http://10.0.0.25:11434');
+});

--- a/test/wizardRecipes.test.js
+++ b/test/wizardRecipes.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const recipes = require('../src/services/wizardRecipes');
+
+test('fishing-pole questions use the versioned vanilla recipe and a visual 3x3 grid', () => {
+  assert.equal(
+    recipes.recipeReply('how do I craft myself a fishing pole using a crafting table?', '1.20.1'),
+    ['Fishing Rod ×1 — 3×3', '[ ][ ][1]', '[ ][1][2]', '[1][ ][2]', '1 Stick ×3 · 2 String ×2'].join('\n')
+  );
+});
+
+test('2x2 and shapeless recipes are rendered into bounded square grids', () => {
+  const table = recipes.recipeReply('what is the crafting recipe for a crafting table?', '1.20.1');
+  assert.match(table, /^Crafting Table ×1 — 2×2\n(?:\[1\]){2}\n(?:\[1\]){2}\n1 Oak Planks ×4$/);
+  const data = recipes.dataForVersion('1.20.1');
+  const item = { name: 'example', displayName: 'Example' };
+  assert.equal(
+    recipes.renderRecipe(item, { ingredients: [807, 810], result: { count: 1 } }, data),
+    ['Example ×1 — 2×2 shapeless', '[1][2]', '[ ][ ]', '1 Stick ×1 · 2 String ×1'].join('\n')
+  );
+});
+
+test('unknown or modded recipes are not invented and non-crafting questions pass through', () => {
+  assert.match(recipes.recipeReply('how do I craft an allthemodium furnace?', '1.20.1'), /cannot verify/i);
+  assert.match(recipes.recipeReply('how do I craft a netherite pickaxe?', '1.20.1'), /no 2×2 or 3×3.*smithing table/i);
+  assert.equal(recipes.recipeReply('how do I make it rain?', '1.20.1'), null);
+  assert.equal(recipes.recipeReply('tell me a story about a fish', '1.20.1'), null);
+});
+
+test('common spoken aliases and verified processing hints remain deterministic', () => {
+  const expected = 'Smelt Sand or Red Sand in a furnace to make Glass.';
+  assert.match(recipes.recipeReply('what is the recipe for glass?', '1.20.1'), new RegExp(`^${expected}`));
+  assert.match(recipes.recipeReply('how do I make a glass block?', '1.20.1'), new RegExp(`^${expected}`));
+});
+
+test('generic item families ask the player to choose a specific craftable item', () => {
+  assert.equal(
+    recipes.recipeReply('how do I craft a pickaxe?', '1.20.1'),
+    'Which kind? Try Wooden Pickaxe, Stone Pickaxe, Golden Pickaxe, Iron Pickaxe, or Diamond Pickaxe.'
+  );
+  assert.match(recipes.recipeReply('how do I craft an iron pickaxe?', '1.20.1'), /^Iron Pickaxe ×1 — 3×3/);
+});
+
+test('unsupported pinned versions do not silently substitute a different recipe version', () => {
+  assert.equal(recipes.dataForVersion('1.25.1'), null);
+  assert.match(recipes.recipeReply('how do I craft an iron pickaxe?', '1.25.1'), /cannot verify.*1\.25\.1/i);
+});

--- a/views/partials/server/integrations.hbs
+++ b/views/partials/server/integrations.hbs
@@ -1,5 +1,152 @@
 <div class="grid gap-4 lg:grid-cols-2" id="ig-root" data-server-id="{{server.id}}" data-invite="{{json integrations.invite}}">
 
+  {{#if integrations.wizard}}
+  <div class="card p-4 lg:col-span-2" id="ig-wizard">
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h3 class="flex items-center gap-2 font-semibold">{{{icon 'sparkles' 'size-4 text-link'}}} Chatbot settings</h3>
+        <p class="mt-1 text-xs text-ink-faint">Players invoke this chatbot with <code class="rounded bg-inset px-1">@{{integrations.wizard.invocationName}}</code>. Configuration and transcripts are visible only to admins.</p>
+      </div>
+      <span class="msm-toggle"><input type="checkbox" id="ig-wz-enabled" {{#if integrations.wizard.enabled}}checked{{/if}}><span></span></span>
+    </div>
+
+    <div class="grid gap-4 lg:grid-cols-2">
+      <div class="space-y-4">
+        <div>
+          <label class="label" for="ig-wz-name">Invocation name</label>
+          <div class="flex items-center gap-1">
+            <span class="font-mono text-sm text-ink-faint">@</span>
+            <input class="input font-mono text-xs" id="ig-wz-name" maxlength="32" pattern="[A-Za-z][A-Za-z0-9_-]{0,31}" value="{{integrations.wizard.invocationName}}" placeholder="wizard">
+          </div>
+          <p class="help">Players call the chatbot with this name, for example <code class="rounded bg-inset px-1">@bubba</code>. It also becomes the chatbot's chat and transcript label.</p>
+        </div>
+        <div>
+          <label class="label" for="ig-wz-url">OpenAI-compatible base URL</label>
+          <input class="input font-mono text-xs" id="ig-wz-url" value="{{integrations.wizard.baseUrl}}" placeholder="http://192.168.1.50:11434">
+          <p class="help">Ollama works with its host and port; <code class="rounded bg-inset px-1">/v1</code> is added automatically. LAN/private addresses are supported.</p>
+        </div>
+        <div>
+          <label class="label" for="ig-wz-model">Model</label>
+          <div class="flex gap-2">
+            <input class="input min-w-0 flex-1 font-mono text-xs" id="ig-wz-model" list="ig-wz-models" value="{{integrations.wizard.model}}" placeholder="llama3.2:latest">
+            <datalist id="ig-wz-models"></datalist>
+            <button class="btn shrink-0" id="ig-wz-models-load">Discover</button>
+          </div>
+          <p class="help">Discovery fills suggestions; free text always remains available.</p>
+        </div>
+        <div>
+          <label class="label" for="ig-wz-key">API key <span class="font-normal text-ink-faint">(optional)</span></label>
+          <input class="input font-mono text-xs" type="password" id="ig-wz-key" autocomplete="new-password" placeholder="{{#if integrations.wizard.hasApiKey}}Stored securely — leave blank to keep{{else}}Not required by default Ollama installs{{/if}}">
+          {{#if integrations.wizard.hasApiKey}}
+            <label class="mt-2 flex items-center gap-2 text-xs"><input type="checkbox" class="msm-check" id="ig-wz-key-clear"> Remove stored key on save</label>
+          {{/if}}
+        </div>
+        <div>
+          <label class="label" for="ig-wz-retention">Transcript retention</label>
+          <div class="flex items-center gap-2">
+            <input class="input w-28" type="number" id="ig-wz-retention" min="0" max="3650" value="{{integrations.wizard.retentionDays}}">
+            <span class="text-sm text-ink-soft">days</span>
+          </div>
+          <p class="help">Default 7. Set 0 to store no transcripts. Existing transcripts remain associated with deleted servers until this period expires.</p>
+        </div>
+      </div>
+
+      <div>
+        <label class="label" for="ig-wz-prompt">Chatbot persona and system prompt</label>
+        <textarea class="input min-h-72 font-mono text-xs leading-5" id="ig-wz-prompt" maxlength="12000">{{integrations.wizard.systemPrompt}}</textarea>
+        <p class="help">This is sent as the system message for this server. Powers are exposed as fixed, validated tools—never raw console commands.</p>
+      </div>
+    </div>
+
+    <div class="mt-5 rounded-md border border-line bg-inset p-4">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h4 class="font-semibold">Player outreach</h4>
+          <p class="help">Deterministic per-session greetings and check-ins. No LLM call is needed to send them.</p>
+        </div>
+        <label class="flex items-center gap-2 text-sm"><span>Greet players on join</span><span class="msm-toggle"><input type="checkbox" id="ig-wz-welcome-enabled" {{#if integrations.wizard.welcomeEnabled}}checked{{/if}}><span></span></span></label>
+      </div>
+      <div class="mt-4 grid gap-4 lg:grid-cols-2">
+        <div>
+          <label class="label" for="ig-wz-welcome-message">Join greeting</label>
+          <textarea class="input min-h-24 text-xs" id="ig-wz-welcome-message" maxlength="400">{{integrations.wizard.welcomeMessage}}</textarea>
+          <p class="help">Broadcast once when a player joins. Variables: <code>{player}</code>, <code>{chatbot}</code>, and <code>{mention}</code>. The older <code>{wizard}</code> variable remains supported.</p>
+        </div>
+        <div>
+          <label class="label" for="ig-wz-checkin-message">Playtime check-in</label>
+          <textarea class="input min-h-24 text-xs" id="ig-wz-checkin-message" maxlength="400">{{integrations.wizard.checkinMessage}}</textarea>
+          <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
+            <span>Send privately after</span>
+            <input class="input w-24" type="number" id="ig-wz-checkin-minutes" min="0" max="1440" value="{{integrations.wizard.checkinMinutes}}">
+            <span class="text-ink-soft">minutes online</span>
+          </div>
+          <p class="help">Sent once per play session. Set 0 to disable. The message may also use <code>{minutes}</code>.</p>
+        </div>
+      </div>
+      <div class="mt-4">
+        <label class="label" for="ig-wz-conversation-minutes">Opt-in conversation mode</label>
+        <div class="flex flex-wrap items-center gap-2 text-sm">
+          <span>Keep listening for</span>
+          <input class="input w-24" type="number" id="ig-wz-conversation-minutes" min="0" max="60" value="{{integrations.wizard.conversationMinutes}}">
+          <span class="text-ink-soft">minutes after a player says <code>@{{integrations.wizard.invocationName}} chat</code></span>
+        </div>
+        <p class="help">During this explicitly opened window, that player can reply without repeating the mention. <code>@{{integrations.wizard.invocationName}} bye</code>, leaving the server, or the timeout closes it. Messages beginning with <code>!</code>, <code>/</code>, or another <code>@</code> are ignored. Set 0 to disable.</p>
+      </div>
+    </div>
+
+    <div class="mt-5 rounded-md border border-line bg-inset p-4">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h4 class="font-semibold">Chatbot powers <span class="text-xs font-normal text-warn">Experimental</span></h4>
+          <p class="help">Basic users receive self/world powers. Controllers receive separately validated powers that may affect another online player. Everyone else remains conversation-only.</p>
+        </div>
+        <label class="flex items-center gap-2 text-sm"><span>Enable powers</span><span class="msm-toggle"><input type="checkbox" id="ig-wz-powers-enabled" {{#if integrations.wizard.powersEnabled}}checked{{/if}}><span></span></span></label>
+      </div>
+      <div class="mt-4 grid gap-4 lg:grid-cols-4">
+        <div>
+          <label class="label" for="ig-wz-testers">Basic users</label>
+          <textarea class="input min-h-28 font-mono text-xs" id="ig-wz-testers" placeholder="Gleep52&#10;PlayerA">{{{joinLines integrations.wizard.powerTesters}}}</textarea>
+          <p class="help">One exact player name per line. Maximum 50.</p>
+        </div>
+        <div>
+          <label class="label" for="ig-wz-controllers">Power controllers</label>
+          <textarea class="input min-h-28 font-mono text-xs" id="ig-wz-controllers" placeholder="Gleep52">{{{joinLines integrations.wizard.powerControllers}}}</textarea>
+          <p class="help">Only these exact players may affect another online player. Their gifts may use any valid item ID, but still obey the quantity limit. Add them to Basic users too if they should retain self/world powers.</p>
+        </div>
+        <div>
+          <label class="label" for="ig-wz-gifts">Allowed gifts</label>
+          <textarea class="input min-h-28 font-mono text-xs" id="ig-wz-gifts">{{{joinLines integrations.wizard.giftItems}}}</textarea>
+          <p class="help">One namespaced item ID per line. Restricts gifts that Basic users give themselves; power controllers may give other players any valid vanilla or modded item.</p>
+        </div>
+        <div class="space-y-3">
+          <label class="flex items-center gap-2 text-sm"><input class="msm-check" type="checkbox" id="ig-wz-dry-run" {{#if integrations.wizard.powersDryRun}}checked{{/if}}> Dry run (audit only; change nothing)</label>
+          <div><label class="label" for="ig-wz-gift-max">Maximum gift quantity</label><input class="input w-28" type="number" id="ig-wz-gift-max" min="1" max="16" value="{{integrations.wizard.giftMaxCount}}"></div>
+          <div><label class="label" for="ig-wz-power-cooldown">Per-player cooldown</label><div class="flex items-center gap-2"><input class="input w-28" type="number" id="ig-wz-power-cooldown" min="3" max="3600" value="{{integrations.wizard.powerCooldownSec}}"><span class="text-sm text-ink-soft">seconds</span></div></div>
+        </div>
+      </div>
+      <div class="mt-4 grid grid-cols-2 gap-2 text-sm sm:grid-cols-3 lg:grid-cols-6">
+        <label class="flex items-center gap-2"><input class="msm-check" type="checkbox" data-wz-power="heal" {{#if integrations.wizard.powerFlags.heal}}checked{{/if}}> Healing</label>
+        <label class="flex items-center gap-2"><input class="msm-check" type="checkbox" data-wz-power="feed" {{#if integrations.wizard.powerFlags.feed}}checked{{/if}}> Feeding</label>
+        <label class="flex items-center gap-2"><input class="msm-check" type="checkbox" data-wz-power="spawn" {{#if integrations.wizard.powerFlags.spawn}}checked{{/if}}> Teleports</label>
+        <label class="flex items-center gap-2"><input class="msm-check" type="checkbox" data-wz-power="time" {{#if integrations.wizard.powerFlags.time}}checked{{/if}}> Time</label>
+        <label class="flex items-center gap-2"><input class="msm-check" type="checkbox" data-wz-power="weather" {{#if integrations.wizard.powerFlags.weather}}checked{{/if}}> Weather</label>
+        <label class="flex items-center gap-2"><input class="msm-check" type="checkbox" data-wz-power="gift" {{#if integrations.wizard.powerFlags.gift}}checked{{/if}}> Gifts</label>
+      </div>
+    </div>
+
+    <div class="mt-4 flex flex-wrap items-center gap-2">
+      <button class="btn btn-primary" id="ig-wz-save">Save chatbot</button>
+      <button class="btn" id="ig-wz-test">Test connection</button>
+      <button class="btn" id="ig-wz-transcripts">Refresh this server's transcripts</button>
+      <button class="btn" id="ig-wz-power-audit">Refresh power audit</button>
+      <a class="btn btn-ghost" href="/wizard-transcripts">All transcript archives</a>
+      <span class="hidden text-xs text-warn" data-ig-dirty="wz">Unsaved changes</span>
+    </div>
+    <div class="mt-4 hidden max-h-80 overflow-auto rounded-md border border-line bg-inset p-3 text-xs" id="ig-wz-transcript-list"></div>
+    <div class="mt-4 hidden max-h-80 overflow-auto rounded-md border border-line bg-inset p-3 text-xs" id="ig-wz-power-audit-list"></div>
+  </div>
+  {{/if}}
+
   <div class="card p-4">
     <div class="mb-4 flex items-center justify-between gap-3">
       <h3 class="flex items-center gap-2 font-semibold">{{{icon 'webhook' 'size-4 text-link'}}} Discord notifications</h3>

--- a/views/wizard-transcripts.hbs
+++ b/views/wizard-transcripts.hbs
@@ -1,0 +1,25 @@
+<div class="mb-5">
+  <p class="text-xs font-medium uppercase tracking-wider text-ink-faint">Administration</p>
+  <h1 class="mt-1 text-2xl font-bold">Chatbot transcript archives</h1>
+  <p class="mt-1 text-sm text-ink-faint">Retained per each server's policy, including conversations from servers that were later deleted.</p>
+</div>
+
+<div class="card overflow-hidden">
+  {{#if transcripts.length}}
+    <div class="divide-y divide-line">
+      {{#each transcripts}}
+        <div class="p-4">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-ink-faint">
+            <span class="font-medium text-ink-soft">{{server_name}}</span>
+            <span class="font-mono">{{server_id}}</span>
+            <span>·</span><span>{{speaker}}</span>
+            <span class="ml-auto" data-ts="{{created_at}}">{{created_at}}</span>
+          </div>
+          <p class="mt-2 whitespace-pre-wrap break-words text-sm {{#if (eq role 'error')}}text-danger{{else}}text-ink{{/if}}">{{content}}</p>
+        </div>
+      {{/each}}
+    </div>
+  {{else}}
+    <div class="p-10 text-center text-sm text-ink-faint">No chatbot transcripts are currently retained.</div>
+  {{/if}}
+</div>


### PR DESCRIPTION
Closes #12.

Adds an admin-configured, per-server Minecraft chatbot backed by OpenAI-compatible chat completions, including Ollama on another LAN host.

## Player experience

- Configurable invocation (`@wizard` by default) and persona per server
- Conversation access for every player, with join greetings, timed check-ins, and an opt-in reply window
- Per-server transcripts with configurable retention
- Deterministic, version-aware vanilla recipe grids; unknown or modded recipes point players to JEI/REI

## Guarded gameplay powers

- Basic users receive enabled self/world actions and allowlisted self-gifts
- Power controllers receive exact-online-player cross-player heal, feed, teleport, and gift actions
- Powers are off and dry-run is on by default
- Per-power flags, quantity limits, cooldowns, exact targets, selector rejection, and a complete audit trail
- The model never receives raw RCON; only the one intent-matched structured tool is exposed, and all arguments are revalidated server-side
- Models without compatible tool calling fall back to conversation only

## Administration and storage

- Configuration and transcript UI are admin-only
- API keys are encrypted at rest
- Endpoint, model, prompt, invocation name, outreach, powers, and retention are configured per server
- Configuration and transcripts persist in the panel SQLite database and survive server soft-deletion until retention expiry
- Internal `wizard` route/table names are retained for compatibility; user-facing terminology is “chatbot”

Technical overview: [`docs/chatbot.md`](docs/chatbot.md)

## Verification

- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run typecheck` — passed
- Focused chatbot tests — 29/29 passed
- `npm run build` — passed
- Full suite — 283/284 passed locally; the remaining existing `safeJoin allows a dangling symlink` test fails on macOS path canonicalization and is outside this change

The branch is based directly on upstream `e3c3d2a` and excludes fork branding, release-version changes, and unrelated fixes.