### PR TITLE
ci: build the Docker image natively per arch instead of under QEMU

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,13 @@ name: Docker
 # an immutable :v<package.json version> tag, multi-arch (amd64 servers, arm64
 # Pi/ARM VPS). Pushing without a version bump republishes both tags for that
 # version, which is harmless. Can also be run manually from the Actions tab.
+#
+# Each arch builds on its OWN native runner and pushes an untagged, by-digest
+# image; the merge job then stitches the two digests into one manifest list.
+# Emulating arm64 on an amd64 runner is not an option here: Node/V8 hits
+# instructions qemu-user mis-emulates and `pnpm install` dies with
+# "uncaught target signal 4 (Illegal instruction)", then hangs until the job
+# is cancelled.
 on:
   push:
     branches: [main]
@@ -14,20 +21,28 @@ permissions:
   packages: write
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
-      - id: version
-        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      # GHCR/OCI tags must be lowercase - github.repository preserves the
+      # GHCR/OCI names must be lowercase - github.repository preserves the
       # owner's actual casing (e.g. OwenWright8/...), which buildx rejects.
-      - name: Lowercase image name
-        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+      - name: Prepare env
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -36,13 +51,66 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      # No tags here: push-by-digest uploads the layers and manifest without
+      # claiming a tag, so the two arches cannot clobber each other's :latest.
+      - id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.value }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          # Scoped per arch - a shared gha cache key would have the two builds
+          # overwriting each other's manifest.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: version
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/${IMAGE_NAME}:latest" \
+            -t "ghcr.io/${IMAGE_NAME}:v${{ steps.version.outputs.value }}" \
+            $(printf "ghcr.io/${IMAGE_NAME}@sha256:%s " *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "ghcr.io/${IMAGE_NAME}:v${{ steps.version.outputs.value }}"


### PR DESCRIPTION
The arm64 leg was cross-built under qemu-user on an amd64 runner. Node 24 hits instructions QEMU mis-emulates, so `pnpm install` died with "uncaught target signal 4 (Illegal instruction) - core dumped" in both the build and runtime stages. It wedged rather than failing, and with no timeout the job ran the full 6h before being cancelled.

Build each arch on its own native runner (ubuntu-latest / ubuntu-24.04-arm), push untagged by-digest images, and stitch them into one manifest list in a merge job that applies :latest and :v<version>. GHA cache scopes are split per arch so the two builds do not clobber each other's manifest, and both jobs now carry timeout-minutes so a future hang costs minutes, not hours.