### PR TITLE
Update safety: kill the last unpinned-modpack path, make the update policy real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each push is cut as a new release with
 its own dated entry.
 
+## [0.12.0] - 2026-09-04
+
+An update-safety release: the last unpinned-modpack path is gone, and the per-server update
+policy finally does what it says - including a real, guarded auto-update mode. (#22, #24)
+
+### Added
+
+- **The update policy is now real.** *Manual only* excludes the server from the update badge, the
+  Updates page, and the daily check's notifications entirely - the true "never touch my versions"
+  mode. *Auto-update* applies pending **pack** updates after the scheduled daily check through the
+  same guarded path as a manual upgrade: pre-update backup, first-boot health monitoring, and an
+  **automatic rollback** when the new version fails to come up. Updates that would change the
+  server's Minecraft version are always skipped with an event - world conversion stays a human
+  decision. The manual "check now" buttons never trigger auto-updates. Previously all three
+  options were stored but changed nothing.
+- The README now points to the new **community Discord** (support forum, showcase, dev corner).
+
+### Fixed
+
+- **No more silent modpack self-updates.** Servers created before 0.9.7 (or with hand-edited env)
+  could carry a pack selector with no version pin, making the container image download the newest
+  pack version on every start - the failure mode behind lost worlds in #21/#22. A boot sweep now
+  pins every such server to the version that is *actually installed* (from the panel's own record
+  or the image's install manifest, with the pack slug cross-checked - never a freshly resolved
+  "latest"), backfills the panel's pack record so these servers join the guarded upgrade flow, and
+  flags the container for recreate. Servers with no readable evidence get a prominent Settings
+  warning with a manual version picker instead of a guess.
+- Every path that writes server env (create, config update, blueprint import) now **rejects an
+  unpinned pack selector** outright, so the state can't come back.
+- The settings-page policy radios and the modpacks doc now describe the actual behavior of each
+  option.
+
 ## [0.11.0] - 2026-09-01
 
 A content-sources release: three new keyless registries, server-side `.mrpack` import,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ policy finally does what it says - including a real, guarded auto-update mode. (
 
 ### Added
 
-- **The update policy is now real.** *Manual only* excludes the server from the update badge, the
+- **The update policy is now real.** _Manual only_ excludes the server from the update badge, the
   Updates page, and the daily check's notifications entirely - the true "never touch my versions"
-  mode. *Auto-update* applies pending **pack** updates after the scheduled daily check through the
+  mode. _Auto-update_ applies pending **pack** updates after the scheduled daily check through the
   same guarded path as a manual upgrade: pre-update backup, first-boot health monitoring, and an
   **automatic rollback** when the new version fails to come up. Updates that would change the
   server's Minecraft version are always skipped with an event - world conversion stays a human
@@ -27,7 +27,7 @@ policy finally does what it says - including a real, guarded auto-update mode. (
 - **No more silent modpack self-updates.** Servers created before 0.9.7 (or with hand-edited env)
   could carry a pack selector with no version pin, making the container image download the newest
   pack version on every start - the failure mode behind lost worlds in #21/#22. A boot sweep now
-  pins every such server to the version that is *actually installed* (from the panel's own record
+  pins every such server to the version that is _actually installed_ (from the panel's own record
   or the image's install manifest, with the pack slug cross-checked - never a freshly resolved
   "latest"), backfills the panel's pack record so these servers join the guarded upgrade flow, and
   flags the container for recreate. Servers with no readable evidence get a prominent Settings

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ copy to migrate.**
 | 🚀 [Installation](#installation) | ✨ [Getting Started](docs/getting-started.md) | 📜 [Documentation](docs/README.md) | 🖼️ [Screenshots](#screenshots) |
 | -------------------------------- | --------------------------------------------- | ---------------------------------- | ------------------------------ |
 
+<h3 align="center">💬 We now have a Discord!</h3>
+
+<p align="center">
+  <b>Report bugs, suggest features, get help from real humans, and show off your servers.</b><br>
+  There's a support forum, a showcase for your creations, and a dev corner if you want to contribute.
+</p>
+
+<p align="center">
+  <a href="https://discord.gg/Ud6TrQkbDZ"><img src="https://img.shields.io/badge/Join%20the%20MSM%20Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge" alt="Join the MSM Discord"></a>
+</p>
+
 ## Features
 
 - 🐳 Every server is its own **resource-capped Docker container** - create / start / stop / restart / recreate / delete with graceful RCON stop and crash detection

--- a/docs/modpacks.md
+++ b/docs/modpacks.md
@@ -18,7 +18,7 @@ The **Modpacks** page (and the **From modpack** tab in the [creation wizard](ser
 
 When you pick a pack, the panel resolves the exact version, records it, and installs that. On the **Updates** page you'll be told when a newer version is available; upgrading is a deliberate, guarded action with a pre-update backup and rollback. Stable-tracking servers are never offered a beta.
 
-Servers created on very old panel versions (before 0.9.7) could be left *unpinned*, meaning the container image would quietly install the newest pack version on every start. The panel now repairs these at boot: it locks each one to the version that is actually installed (read from the panel's own records or the image's install manifest - never a freshly resolved "latest") and logs an event. If it can't tell what's installed, the server's Settings page shows a warning asking you to pick the version manually, and any attempt to save an unpinned modpack configuration is rejected outright.
+Servers created on very old panel versions (before 0.9.7) could be left _unpinned_, meaning the container image would quietly install the newest pack version on every start. The panel now repairs these at boot: it locks each one to the version that is actually installed (read from the panel's own records or the image's install manifest - never a freshly resolved "latest") and logs an event. If it can't tell what's installed, the server's Settings page shows a warning asking you to pick the version manually, and any attempt to save an unpinned modpack configuration is rejected outright.
 
 ## Update policy
 

--- a/docs/modpacks.md
+++ b/docs/modpacks.md
@@ -16,7 +16,17 @@ The **Modpacks** page (and the **From modpack** tab in the [creation wizard](ser
 
 ## How pinning works
 
-When you pick a pack, the panel resolves the exact version, records it, and installs that. On the **Updates** page you'll be told when a newer version is available; upgrading is a deliberate, guarded action with a pre-update backup and rollback - never automatic. Stable-tracking servers are never offered a beta.
+When you pick a pack, the panel resolves the exact version, records it, and installs that. On the **Updates** page you'll be told when a newer version is available; upgrading is a deliberate, guarded action with a pre-update backup and rollback. Stable-tracking servers are never offered a beta.
+
+Servers created on very old panel versions (before 0.9.7) could be left *unpinned*, meaning the container image would quietly install the newest pack version on every start. The panel now repairs these at boot: it locks each one to the version that is actually installed (read from the panel's own records or the image's install manifest - never a freshly resolved "latest") and logs an event. If it can't tell what's installed, the server's Settings page shows a warning asking you to pick the version manually, and any attempt to save an unpinned modpack configuration is rejected outright.
+
+## Update policy
+
+Each server has an update policy in **Settings**, and all three options mean what they say:
+
+- **Manual only** - nothing ever changes on its own, and the server is left out of the update badge and Updates page entirely. The "leave me alone" mode: ideal for a hand-tuned or imported pack you never want touched.
+- **Notify me** (default) - the daily check surfaces available updates as a badge and on the Updates page; applying them is always your click.
+- **Auto-update** - after the scheduled daily check, pending **pack** updates are applied through the same guarded path as a manual upgrade: pre-update backup, health monitoring, and an automatic rollback if the new version fails to boot. Updates that would move the server to a different Minecraft version are always skipped with an event instead - converting a world permanently is a decision the panel refuses to make for you. The manual "check now" buttons only check; they never trigger auto-updates.
 
 ## Upgrading a pack
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minecraft-server-manager",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Minecraft Server Manager - a complete control panel for itzg/docker-minecraft-server",
   "private": true,
   "license": "MIT",

--- a/src/server.js
+++ b/src/server.js
@@ -83,6 +83,16 @@ try {
   }
 
   require('./services/apiKeys').importFromEnvOnce();
+
+  // Servers from before 0.9.7 (or with hand-edited env) can still carry an
+  // unpinned modpack selector, which silently auto-updates on every start
+  // (#22). Pin them to what's already installed; no-op once repaired.
+  try {
+    require('./services/packPins').pinUnpinnedServers();
+  } catch (err) {
+    logger.error('The unpinned-modpack sweep failed.', { err: serializeError(err) });
+  }
+
   require('./blueprints')
     .seedStarters()
     .catch((err) => logger.error('Seeding starter blueprints failed.', { err: serializeError(err) }));

--- a/src/services/packPins.js
+++ b/src/services/packPins.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// The panel's pinning invariant, in one place: a pack selector env var
+// (CurseForge slug/page URL, Modrinth project, FTB pack id, GTNH type) must
+// always be accompanied by its version pin, or the container image resolves
+// "latest" again on EVERY start and silently upgrades the server (see
+// packs.js - installs have pinned since 0.9.7, but servers created before
+// that, or env edited by hand, can still carry the unpinned shape).
+
+const httpError = require('../utils/httpError');
+
+const has = (env, key) => env[key] != null && String(env[key]).trim() !== '';
+
+/**
+ * Detect unpinned pack selectors in a server's (type, env).
+ * Returns [] when safe, else one entry per selector:
+ * { platform, pinKey, message }.
+ */
+function unpinnedPackSelectors(type, env = {}) {
+  const issues = [];
+
+  // CurseForge: a slug or page URL without CF_FILE_ID. A page URL naming a
+  // specific file (…/files/<id>) is itself a pin, and CF_MODPACK_ZIP is a
+  // fixed local file with nothing to resolve.
+  if ((has(env, 'CF_SLUG') || has(env, 'CF_PAGE_URL')) && !has(env, 'CF_MODPACK_ZIP')) {
+    const pagePinned = has(env, 'CF_PAGE_URL') && /\/files\/\d+/.test(env.CF_PAGE_URL);
+    if (!has(env, 'CF_FILE_ID') && !pagePinned) {
+      issues.push({
+        platform: 'curseforge',
+        pinKey: 'CF_FILE_ID',
+        message:
+          'The CurseForge modpack has no pinned file (CF_FILE_ID): the container would install the newest pack version on every start.',
+      });
+    }
+  }
+
+  // Modrinth: a project without MODRINTH_VERSION. A /version/ URL is a pin.
+  if (has(env, 'MODRINTH_MODPACK')) {
+    const urlPinned = /\/version\//.test(env.MODRINTH_MODPACK);
+    if (!has(env, 'MODRINTH_VERSION') && !urlPinned) {
+      issues.push({
+        platform: 'modrinth',
+        pinKey: 'MODRINTH_VERSION',
+        message:
+          'The Modrinth modpack has no pinned version (MODRINTH_VERSION): the container would install the newest pack version on every start.',
+      });
+    }
+  }
+
+  // FTB: pack id without a version id.
+  if (has(env, 'FTB_MODPACK_ID') && !has(env, 'FTB_MODPACK_VERSION_ID')) {
+    issues.push({
+      platform: 'ftb',
+      pinKey: 'FTB_MODPACK_VERSION_ID',
+      message:
+        'The FTB modpack has no pinned version (FTB_MODPACK_VERSION_ID): the container would install the newest pack version on every start.',
+    });
+  }
+
+  // GTNH: the type alone selects the pack; without GTNH_PACK_VERSION the
+  // image installs the newest release on every start.
+  if (type === 'GTNH' && !has(env, 'GTNH_PACK_VERSION')) {
+    issues.push({
+      platform: 'gtnh',
+      pinKey: 'GTNH_PACK_VERSION',
+      message:
+        'The GTNH server has no pinned pack version (GTNH_PACK_VERSION): the container would install the newest release on every start.',
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Reject an env write that would leave a pack selector unpinned. Every path
+ * that persists server env (create, config update, blueprint import) calls
+ * this; applyPack is pinned by construction and never trips it.
+ */
+function assertPinnedPackEnv(type, env) {
+  const issues = unpinnedPackSelectors(type, env);
+  if (!issues.length) return;
+  throw httpError(
+    400,
+    `${issues.map((i) => i.message).join(' ')} Pick a version in the modpack installer UI (or set ${issues
+      .map((i) => i.pinKey)
+      .join(', ')}) instead.`
+  );
+}
+
+module.exports = { unpinnedPackSelectors, assertPinnedPackEnv };

--- a/src/services/packPins.js
+++ b/src/services/packPins.js
@@ -7,7 +7,9 @@
 // packs.js - installs have pinned since 0.9.7, but servers created before
 // that, or env edited by hand, can still carry the unpinned shape).
 
+const path = require('node:path');
 const httpError = require('../utils/httpError');
+const logger = require('../logger')(path.basename(__filename));
 
 const has = (env, key) => env[key] != null && String(env[key]).trim() !== '';
 
@@ -87,4 +89,127 @@ function assertPinnedPackEnv(type, env) {
   );
 }
 
-module.exports = { unpinnedPackSelectors, assertPinnedPackEnv };
+// ---- boot-time repair of already-unpinned servers ---------------------------
+
+/**
+ * The version pin to adopt for one unpinned selector, from best evidence:
+ * 1. the server's own server_packs row (the panel's recorded intent), else
+ * 2. the image's install manifest in the data dir - what is ACTUALLY installed
+ *    (.curseforge-manifest.json / .modrinth-manifest.json, written by
+ *    mc-image-helper; slug is cross-checked so a leftover manifest from a
+ *    different pack can't mis-pin).
+ * Never resolves "latest": no evidence → no pin (the settings UI shows an
+ * unpinned warning with a manual picker instead).
+ */
+function findPinEvidence(server, issue) {
+  const pack = require('./packs').getPack(server.id);
+  if (pack && pack.platform === issue.platform && pack.pinned_version_id) {
+    return {
+      pin: String(pack.pinned_version_id),
+      name: pack.pinned_version_name || String(pack.pinned_version_id),
+      source: 'panel record',
+    };
+  }
+
+  const fs = require('node:fs');
+  const { dataPath } = require('../storage/pathGuard');
+  const readManifest = (file) => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(dataPath('servers', server.id), file), 'utf8'));
+    } catch {
+      return null; // absent or unreadable - simply not evidence
+    }
+  };
+
+  if (issue.platform === 'curseforge') {
+    const m = readManifest('.curseforge-manifest.json');
+    if (!m || !m.fileId) return null;
+    const expected =
+      (server.env.CF_SLUG || '').trim().toLowerCase() ||
+      (String(server.env.CF_PAGE_URL || '').match(/\/modpacks\/([^/?#]+)/i) || [])[1]?.toLowerCase();
+    if (expected && m.slug && m.slug.toLowerCase() !== expected) return null;
+    return {
+      pin: String(m.fileId),
+      name: m.modpackVersion || m.fileName || String(m.fileId),
+      source: 'installed manifest',
+      manifest: m,
+    };
+  }
+  if (issue.platform === 'modrinth') {
+    const m = readManifest('.modrinth-manifest.json');
+    if (!m || !m.versionId) return null;
+    const ref = String(server.env.MODRINTH_MODPACK || '').trim();
+    const expected = ref && !ref.includes('/') ? ref.toLowerCase() : null;
+    if (expected && m.projectSlug && m.projectSlug.toLowerCase() !== expected) return null;
+    return { pin: String(m.versionId), name: String(m.versionId), source: 'installed manifest', manifest: m };
+  }
+  return null; // ftb/gtnh: no on-disk manifest to trust - panel record only
+}
+
+/**
+ * One-shot boot repair (idempotent: pinned servers stop matching): pin every
+ * unpinned pack selector to the version that is already installed, so the
+ * next recreate can't silently upgrade it. Evidence-less servers are only
+ * logged - the UI warns and offers a manual pick.
+ */
+function pinUnpinnedServers() {
+  const db = require('../db');
+  const { recordEvent } = require('../events');
+  const serversService = require('./servers');
+  let pinned = 0;
+  let unresolved = 0;
+
+  for (const server of serversService.listServers()) {
+    const issues = unpinnedPackSelectors(server.type, server.env);
+    if (!issues.length) continue;
+    const env = { ...server.env };
+    const applied = [];
+    for (const issue of issues) {
+      const evidence = findPinEvidence(server, issue);
+      if (!evidence) {
+        unresolved += 1;
+        logger.warn('A server has an unpinned modpack and no installed version could be read - pin it manually.', {
+          serverId: server.id,
+          platform: issue.platform,
+        });
+        continue;
+      }
+      env[issue.pinKey] = evidence.pin;
+      applied.push({ issue, evidence });
+    }
+    if (!applied.length) continue;
+
+    db.run('UPDATE servers SET env_json = ?, pending_recreate = 1 WHERE id = ?', JSON.stringify(env), server.id);
+    for (const { issue, evidence } of applied) {
+      // A CF manifest carries enough to give a legacy server the server_packs
+      // row the upgrade/update-check flows key off; never clobber an existing row.
+      if (evidence.manifest && issue.platform === 'curseforge') {
+        db.run(
+          `INSERT INTO server_packs (server_id, platform, project_ref, project_name, pinned_version_id, pinned_version_name)
+           VALUES (?, 'curseforge', ?, ?, ?, ?) ON CONFLICT(server_id) DO NOTHING`,
+          server.id,
+          evidence.manifest.slug || server.env.CF_SLUG || '?',
+          evidence.manifest.modpackName || evidence.manifest.slug || 'CurseForge modpack',
+          evidence.pin,
+          evidence.name
+        );
+      }
+      recordEvent({
+        serverId: server.id,
+        actor: 'system',
+        type: 'pack-pinned',
+        summary: `Locked the ${issue.platform} modpack to the installed version (${evidence.name}) - it was set to auto-update on every start`,
+        details: { pinKey: issue.pinKey, pin: evidence.pin, source: evidence.source },
+      });
+      pinned += 1;
+    }
+    logger.info('Pinned an unpinned modpack server to its installed version.', {
+      serverId: server.id,
+      pins: applied.map(({ issue, evidence }) => `${issue.pinKey}=${evidence.pin} (${evidence.source})`),
+    });
+  }
+  if (pinned || unresolved) logger.info('Finished the unpinned-modpack sweep.', { pinned, unresolved });
+  return { pinned, unresolved };
+}
+
+module.exports = { unpinnedPackSelectors, assertPinnedPackEnv, pinUnpinnedServers };

--- a/src/services/scheduler.js
+++ b/src/services/scheduler.js
@@ -64,6 +64,10 @@ async function runTask(schedule) {
     }
     case 'update-check':
       await require('../updates/checker').checkAll({ actor });
+      // Only the scheduled daily check triggers auto-updates - the manual
+      // "check now" buttons never apply anything (#24; the settings-page
+      // policy label promises exactly this).
+      await require('../updates/upgrade').runAutoUpgrades({ actor });
       break;
     case 'storage-scan':
       await require('../storage/indexer').scan();

--- a/src/services/servers.js
+++ b/src/services/servers.js
@@ -274,6 +274,9 @@ async function createServerImpl(input, { actor = 'system', start = false, onProg
       'CurseForge needs an API key - add yours in Settings → API keys first (console.curseforge.com), then create the server.'
     );
   }
+  // Same fail-fast idea for the pinning invariant: an unpinned pack selector
+  // would make the image re-resolve "latest" on every start (issue #22).
+  require('./packPins').assertPinnedPackEnv(input.type, inputEnv);
 
   const id = `srv_${nanoid(8)}`;
 
@@ -652,6 +655,9 @@ function updateServer(id, changes, { actor = 'system' } = {}) {
     params.push(JSON.stringify(changes.tags));
   }
   if (changes.env) {
+    // The type column is not editable here, so the pinning check runs against
+    // the server's existing type with the incoming env (issue #22).
+    require('./packPins').assertPinnedPackEnv(before.type, changes.env);
     diff.env = ['(changed)', '(changed)'];
     sets.push('env_json = ?');
     params.push(JSON.stringify(changes.env));

--- a/src/updates/checker.js
+++ b/src/updates/checker.js
@@ -47,6 +47,11 @@ async function checkAll({ actor = 'scheduler' } = {}) {
   // and resolve each DISTINCT ref once per run rather than once per server.
   const imageIdCache = new Map();
   for (const server of serversService.listServers()) {
+    // 'manual' means "leave me alone": the check rows are still refreshed (so
+    // flipping the policy later shows current state instantly), but nothing
+    // lands in findings - no badge, no "updates available" event, no bridge
+    // notification (#24).
+    const quiet = server.update_policy === 'manual';
     // Pack updates
     try {
       const result = await packsService.latestFor(server.id);
@@ -63,7 +68,7 @@ async function checkAll({ actor = 'scheduler' } = {}) {
           latestName: result.latest.name,
           changelogUrl: changelog,
         });
-        if (result.updateAvailable)
+        if (result.updateAvailable && !quiet)
           findings.push({
             server: server.display_name,
             kind: 'pack',
@@ -128,7 +133,7 @@ async function checkAll({ actor = 'scheduler' } = {}) {
             latestName: latest.name,
             changelogUrl: isNew ? changelogUrl : null,
           });
-          if (isNew)
+          if (isNew && !quiet)
             findings.push({
               server: server.display_name,
               kind: 'mod',
@@ -164,7 +169,7 @@ async function checkAll({ actor = 'scheduler' } = {}) {
         const latestId = imageIdCache.get(ref);
         const isNew = Boolean(latestId) && latestId !== status.imageId;
         upsertCheck('image', server.id, status.imageId, { isNew, latestId, latestName: ref, changelogUrl: null });
-        if (isNew)
+        if (isNew && !quiet)
           findings.push({
             server: server.display_name,
             kind: 'image',
@@ -185,7 +190,7 @@ async function checkAll({ actor = 'scheduler' } = {}) {
     // already resolve to newest on every recreate; nothing to check there).
     if (!packsService.getPack(server.id)) {
       try {
-        await checkStandaloneVersion(server, findings);
+        await checkStandaloneVersion(server, quiet ? [] : findings);
       } catch (err) {
         logger.debug('A standalone version update check failed; keeping the cached result.', {
           serverId: server.id,
@@ -313,7 +318,10 @@ function listOutdated() {
   const rows = [];
   for (const c of db.all('SELECT * FROM update_checks WHERE latest_version IS NOT NULL')) {
     if (c.subject_type === 'pack') {
-      const server = db.get('SELECT id, display_name FROM servers WHERE id = ? AND deleted_at IS NULL', c.subject_id);
+      const server = db.get(
+        "SELECT id, display_name FROM servers WHERE id = ? AND deleted_at IS NULL AND update_policy != 'manual'",
+        c.subject_id
+      );
       const pack = db.get('SELECT * FROM server_packs WHERE server_id = ?', c.subject_id);
       if (server && pack && pack.pinned_version_id !== c.latest_version) {
         rows.push({
@@ -329,7 +337,9 @@ function listOutdated() {
       }
     } else if (c.subject_type === 'content') {
       const row = db.get(
-        `SELECT sc.*, s.display_name, s.id AS sid FROM server_content sc JOIN servers s ON s.id = sc.server_id AND s.deleted_at IS NULL WHERE sc.id = ?`,
+        `SELECT sc.*, s.display_name, s.id AS sid FROM server_content sc
+           JOIN servers s ON s.id = sc.server_id AND s.deleted_at IS NULL AND s.update_policy != 'manual'
+         WHERE sc.id = ?`,
         c.subject_id
       );
       // Name-to-name: skip rows the user already updated since the last check.
@@ -347,6 +357,7 @@ function listOutdated() {
       }
     } else if (c.subject_type === 'image') {
       const server = serversService.getServer(c.subject_id);
+      if (server && server.update_policy === 'manual') continue;
       // No durable local field records "the image this container was built
       // from" - a stale row simply self-corrects on the next checkAll() run
       // (re-pull + re-compare), same eventual-consistency window as everything
@@ -365,6 +376,7 @@ function listOutdated() {
       }
     } else if (c.subject_type === 'mc_version') {
       const server = serversService.getServer(c.subject_id);
+      if (server && server.update_policy === 'manual') continue;
       if (server && server.mc_version === c.current_version) {
         rows.push({
           serverId: server.id,
@@ -379,6 +391,7 @@ function listOutdated() {
       }
     } else if (c.subject_type === 'loader_build') {
       const server = serversService.getServer(c.subject_id);
+      if (server && server.update_policy === 'manual') continue;
       if (server) {
         const loader = modsService.loaderOf(server);
         const envKey = loader && LOADER_BUILD_ENV_KEY[loader];
@@ -413,26 +426,26 @@ function countOutdated() {
     SELECT
       (SELECT COUNT(*) FROM update_checks c
          JOIN server_packs p ON p.server_id = c.subject_id
-         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL
+         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL AND s.update_policy != 'manual'
          WHERE c.subject_type = 'pack' AND c.latest_version IS NOT NULL
            AND p.pinned_version_id != c.latest_version)
       +
       (SELECT COUNT(*) FROM update_checks c
          JOIN server_content sc ON sc.id = c.subject_id
-         JOIN servers s ON s.id = sc.server_id AND s.deleted_at IS NULL
+         JOIN servers s ON s.id = sc.server_id AND s.deleted_at IS NULL AND s.update_policy != 'manual'
          WHERE c.subject_type = 'content' AND c.latest_version IS NOT NULL
            AND c.latest_name IS NOT NULL AND c.latest_name != sc.version)
       +
       (SELECT COUNT(*) FROM update_checks c
-         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL
+         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL AND s.update_policy != 'manual'
          WHERE c.subject_type = 'image' AND c.latest_version IS NOT NULL AND s.container_id IS NOT NULL)
       +
       (SELECT COUNT(*) FROM update_checks c
-         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL
+         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL AND s.update_policy != 'manual'
          WHERE c.subject_type = 'mc_version' AND c.latest_version IS NOT NULL AND s.mc_version = c.current_version)
       +
       (SELECT COUNT(*) FROM update_checks c
-         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL
+         JOIN servers s ON s.id = c.subject_id AND s.deleted_at IS NULL AND s.update_policy != 'manual'
          WHERE c.subject_type = 'loader_build' AND c.latest_version IS NOT NULL)
       AS total
   `);

--- a/src/updates/upgrade.js
+++ b/src/updates/upgrade.js
@@ -154,6 +154,9 @@ async function upgradePack(
         `The server did not come up healthy after the upgrade. Use rollback to restore ${pack.pinned_version_name}.`
       );
       err.rollbackAvailable = Boolean(backupId);
+      // The unattended auto-update path needs the id to roll back without a
+      // human in the loop; the interactive path keeps offering the button.
+      err.backupId = backupId;
       throw err;
     }
 
@@ -179,6 +182,74 @@ async function upgradePack(
   } finally {
     activeUpgrades.delete(serverId);
   }
+}
+
+/**
+ * Apply pending pack updates for every server whose update_policy is 'auto',
+ * one at a time, straight after the scheduled daily check (deliberately NOT
+ * from the manual "check now" buttons - the settings label promises the daily
+ * check, so that is the only trigger). Unattended safety: the pre-update
+ * backup stays on, cross-MC-version updates are skipped with an event (they
+ * permanently convert the world - always a human decision), and a failed
+ * boot rolls back automatically instead of waiting for a click (#24).
+ */
+async function runAutoUpgrades({ actor = 'scheduler' } = {}) {
+  const db = require('../db');
+  const results = { applied: 0, skipped: 0, failed: 0 };
+  for (const server of serversService.listServers()) {
+    if (server.update_policy !== 'auto') continue;
+    const pack = packsService.getPack(server.id);
+    if (!pack) continue; // packs only for now; images/loaders stay manual
+    const check = db.get(
+      "SELECT * FROM update_checks WHERE subject_type = 'pack' AND subject_id = ? AND latest_version IS NOT NULL",
+      server.id
+    );
+    if (!check || check.latest_version === pack.pinned_version_id) continue;
+    try {
+      await upgradePack(server.id, { versionId: check.latest_version, actor });
+      results.applied += 1;
+    } catch (err) {
+      if (err.requiresVersionConfirm) {
+        results.skipped += 1;
+        recordEvent({
+          serverId: server.id,
+          actor,
+          type: 'auto-update-skipped',
+          summary: `Auto-update to ${check.latest_name || check.latest_version} skipped: it moves Minecraft ${err.fromMcVersion} → ${err.toMcVersion}, which permanently converts the world - apply it manually when ready`,
+        });
+        continue;
+      }
+      results.failed += 1;
+      logger.warn('An automatic pack upgrade failed.', {
+        serverId: server.id,
+        toVersion: check.latest_name || check.latest_version,
+        err: serializeError(err, { includeStack: false }),
+      });
+      if (err.rollbackAvailable && err.backupId) {
+        try {
+          await rollbackPack(server.id, { backupId: err.backupId, actor });
+        } catch (rbErr) {
+          // upgradePack already recorded update-failed; this event is the
+          // "your server needs you" escalation for the truly bad night.
+          recordEvent({
+            serverId: server.id,
+            actor,
+            type: 'auto-update-failed',
+            summary: `Auto-update failed AND the automatic rollback failed - the server needs manual attention (backup ${err.backupId} is intact)`,
+          });
+          logger.error('The automatic rollback after a failed auto-update also failed.', {
+            serverId: server.id,
+            backupId: err.backupId,
+            err: serializeError(rbErr),
+          });
+        }
+      }
+    }
+  }
+  if (results.applied || results.skipped || results.failed) {
+    logger.info('Finished the automatic pack upgrades.', results);
+  }
+  return results;
 }
 
 /** Roll back: restore the pre-update backup + re-pin the previous version. */
@@ -266,4 +337,4 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms).unref());
 }
 
-module.exports = { upgradePack, rollbackPack, upgradeStatus };
+module.exports = { upgradePack, rollbackPack, upgradeStatus, runAutoUpgrades };

--- a/src/web/viewModels.js
+++ b/src/web/viewModels.js
@@ -103,6 +103,10 @@ async function serverVM(s, { withLive = true } = {}) {
     autoRestart: Boolean(s.auto_restart),
     notes: s.notes,
     updatePolicy: s.update_policy,
+    // True only for a server the boot sweep could not repair (no recorded or
+    // installed version to pin to) - the settings page warns and asks for a
+    // manual version pick (#22).
+    packUnpinned: require('../services/packPins').unpinnedPackSelectors(s.type, s.env).length > 0,
     pendingRecreate: Boolean(s.pending_recreate),
     lastStarted: s.last_started_at || '-',
     created: s.created_at,

--- a/test/auto-upgrades.test.js
+++ b/test/auto-upgrades.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+// runAutoUpgrades guardrails: it must touch ONLY servers whose policy is
+// 'auto' AND that have a genuinely pending pack update. Everything else is a
+// no-op - manual/notify servers, up-to-date pins, packless servers (#24).
+// The apply/rollback path itself rides upgradePack/rollbackPack, which the
+// upgrade orchestrator already exercises.
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { migrate } = require('../src/db/migrate');
+migrate();
+const db = require('../src/db');
+const { runAutoUpgrades } = require('../src/updates/upgrade');
+
+let port = 25900;
+function seedServer(id, policy) {
+  port += 2;
+  db.run(
+    `INSERT INTO servers (id, display_name, type, port_game, port_rcon, rcon_password_cipher, heap_mb, container_memory_mb, status, update_policy, env_json)
+     VALUES (?, ?, 'AUTO_CURSEFORGE', ?, ?, 'x', 1024, 1536, 'stopped', ?, '{}')`,
+    id,
+    id,
+    port,
+    port + 1,
+    policy
+  );
+}
+
+function seedPack(id, pinned) {
+  db.run(
+    `INSERT INTO server_packs (server_id, platform, project_ref, project_name, pinned_version_id, pinned_version_name)
+     VALUES (?, 'curseforge', 'atm10', 'All the Mods 10', ?, ?)`,
+    id,
+    pinned,
+    `v${pinned}`
+  );
+}
+
+function seedCheck(id, latest) {
+  db.run(
+    `INSERT INTO update_checks (subject_type, subject_id, current_version, latest_version, latest_name, checked_at)
+     VALUES ('pack', ?, 'v100', ?, ?, datetime('now'))`,
+    id,
+    latest,
+    latest && `v${latest}`
+  );
+}
+
+test('non-auto policies are never touched, even with updates pending', async () => {
+  seedServer('srv_man', 'manual');
+  seedPack('srv_man', '100');
+  seedCheck('srv_man', '200');
+  seedServer('srv_not', 'notify');
+  seedPack('srv_not', '100');
+  seedCheck('srv_not', '200');
+
+  assert.deepEqual(await runAutoUpgrades(), { applied: 0, skipped: 0, failed: 0 });
+});
+
+test('an auto server that is already up to date is a no-op', async () => {
+  seedServer('srv_current', 'auto');
+  seedPack('srv_current', '300');
+  // checker leaves latest_version NULL when up to date; also cover a stale
+  // row that matches the pin exactly.
+  seedCheck('srv_current', '300');
+  assert.deepEqual(await runAutoUpgrades(), { applied: 0, skipped: 0, failed: 0 });
+});
+
+test('an auto server without a managed pack is left alone', async () => {
+  seedServer('srv_packless', 'auto');
+  seedCheck('srv_packless', '200');
+  assert.deepEqual(await runAutoUpgrades(), { applied: 0, skipped: 0, failed: 0 });
+});

--- a/test/checker-manual-policy.test.js
+++ b/test/checker-manual-policy.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// 'manual' update policy must mean "leave me alone": servers set to it are
+// excluded from the Updates page and the sidebar badge count, while 'notify'
+// servers keep appearing (#24). The underlying update_checks rows still exist
+// for both, so flipping the policy back shows current state instantly.
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { migrate } = require('../src/db/migrate');
+migrate();
+const db = require('../src/db');
+const { listOutdated, countOutdated } = require('../src/updates/checker');
+
+function seedPackServer(id, policy) {
+  const port = id === 'srv_manual' ? 25800 : 25802;
+  db.run(
+    `INSERT INTO servers (id, display_name, type, port_game, port_rcon, rcon_password_cipher, heap_mb, container_memory_mb, status, update_policy, env_json)
+     VALUES (?, ?, 'AUTO_CURSEFORGE', ?, ?, 'x', 1024, 1536, 'stopped', ?, '{}')`,
+    id,
+    id,
+    port,
+    port + 1,
+    policy
+  );
+  db.run(
+    `INSERT INTO server_packs (server_id, platform, project_ref, project_name, pinned_version_id, pinned_version_name)
+     VALUES (?, 'curseforge', 'atm10', 'All the Mods 10', '100', '1.0')`,
+    id
+  );
+  db.run(
+    `INSERT INTO update_checks (subject_type, subject_id, current_version, latest_version, latest_name, checked_at)
+     VALUES ('pack', ?, '1.0', '200', '2.0', datetime('now'))`,
+    id
+  );
+}
+
+seedPackServer('srv_manual', 'manual');
+seedPackServer('srv_notify', 'notify');
+
+test('listOutdated hides manual-policy servers and keeps notify ones', () => {
+  const rows = listOutdated();
+  const byServer = rows.map((r) => r.serverId);
+  assert.ok(byServer.includes('srv_notify'), 'notify server should be listed');
+  assert.ok(!byServer.includes('srv_manual'), 'manual server must not be listed');
+});
+
+test('countOutdated matches the same filter', () => {
+  assert.equal(countOutdated(), 1);
+});
+
+test('the check row itself is kept for manual servers', () => {
+  const row = db.get("SELECT * FROM update_checks WHERE subject_type = 'pack' AND subject_id = 'srv_manual'");
+  assert.ok(row && row.latest_version === '200');
+});

--- a/test/packPins-sweep.test.js
+++ b/test/packPins-sweep.test.js
@@ -85,7 +85,10 @@ test('a manifest for a different pack is not trusted', () => {
 
 test('pins an unpinned Modrinth server from its install manifest', () => {
   seedServer('srv_mrmani', 'MODRINTH', { MODRINTH_MODPACK: 'fabulously-optimized' });
-  writeManifest('srv_mrmani', '.modrinth-manifest.json', { projectSlug: 'fabulously-optimized', versionId: 'aBc123Xy' });
+  writeManifest('srv_mrmani', '.modrinth-manifest.json', {
+    projectSlug: 'fabulously-optimized',
+    versionId: 'aBc123Xy',
+  });
   pinUnpinnedServers();
   assert.equal(serverRow('srv_mrmani').env.MODRINTH_VERSION, 'aBc123Xy');
 });

--- a/test/packPins-sweep.test.js
+++ b/test/packPins-sweep.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// pinUnpinnedServers must repair pre-0.9.7 servers (unpinned CF_SLUG /
+// MODRINTH_MODPACK) from real evidence only - the panel's own server_packs
+// row or the image's install manifest - and never guess "latest" (#22).
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { migrate } = require('../src/db/migrate');
+migrate();
+const db = require('../src/db');
+const { dataPath } = require('../src/storage/pathGuard');
+const { pinUnpinnedServers } = require('../src/services/packPins');
+
+let port = 25700;
+function seedServer(id, type, env) {
+  port += 2;
+  db.run(
+    `INSERT INTO servers (id, display_name, type, port_game, port_rcon, rcon_password_cipher, heap_mb, container_memory_mb, status, env_json)
+     VALUES (?, ?, ?, ?, ?, 'x', 1024, 1536, 'stopped', ?)`,
+    id,
+    id,
+    type,
+    port,
+    port + 1,
+    JSON.stringify(env)
+  );
+}
+
+function writeManifest(id, file, content) {
+  const dir = dataPath('servers', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, file), JSON.stringify(content));
+}
+
+function serverRow(id) {
+  const row = db.get('SELECT env_json, pending_recreate FROM servers WHERE id = ?', id);
+  return { env: JSON.parse(row.env_json), pendingRecreate: row.pending_recreate };
+}
+
+test('pins an unpinned CurseForge server from its install manifest', () => {
+  seedServer('srv_cfmani', 'AUTO_CURSEFORGE', { CF_SLUG: 'stoneblock-4' });
+  writeManifest('srv_cfmani', '.curseforge-manifest.json', {
+    slug: 'stoneblock-4',
+    modId: 123456,
+    fileId: 5891234,
+    fileName: 'StoneBlock4-1.2.3.zip',
+    modpackVersion: '1.2.3',
+    modpackName: 'StoneBlock 4',
+  });
+
+  const result = pinUnpinnedServers();
+  assert.ok(result.pinned >= 1);
+  const { env, pendingRecreate } = serverRow('srv_cfmani');
+  assert.equal(env.CF_FILE_ID, '5891234');
+  assert.equal(pendingRecreate, 1);
+  const pack = db.get("SELECT * FROM server_packs WHERE server_id = 'srv_cfmani'");
+  assert.equal(pack.platform, 'curseforge');
+  assert.equal(pack.pinned_version_id, '5891234');
+  assert.equal(pack.pinned_version_name, '1.2.3');
+  const event = db.get("SELECT * FROM events WHERE server_id = 'srv_cfmani' AND type = 'pack-pinned'");
+  assert.ok(event, 'expected a pack-pinned event');
+});
+
+test('pins from the panel server_packs record when there is no manifest', () => {
+  seedServer('srv_dbrec', 'MODRINTH', { MODRINTH_MODPACK: 'cobblemon' });
+  db.run(
+    `INSERT INTO server_packs (server_id, platform, project_ref, project_name, pinned_version_id, pinned_version_name)
+     VALUES ('srv_dbrec', 'modrinth', 'cobblemon', 'Cobblemon', 'VeR51On1', '1.6.1')`
+  );
+  pinUnpinnedServers();
+  assert.equal(serverRow('srv_dbrec').env.MODRINTH_VERSION, 'VeR51On1');
+});
+
+test('a manifest for a different pack is not trusted', () => {
+  seedServer('srv_wrong', 'AUTO_CURSEFORGE', { CF_SLUG: 'all-the-mods-10' });
+  writeManifest('srv_wrong', '.curseforge-manifest.json', { slug: 'some-other-pack', fileId: 99 });
+  const result = pinUnpinnedServers();
+  assert.equal(serverRow('srv_wrong').env.CF_FILE_ID, undefined);
+  assert.ok(result.unresolved >= 1);
+});
+
+test('pins an unpinned Modrinth server from its install manifest', () => {
+  seedServer('srv_mrmani', 'MODRINTH', { MODRINTH_MODPACK: 'fabulously-optimized' });
+  writeManifest('srv_mrmani', '.modrinth-manifest.json', { projectSlug: 'fabulously-optimized', versionId: 'aBc123Xy' });
+  pinUnpinnedServers();
+  assert.equal(serverRow('srv_mrmani').env.MODRINTH_VERSION, 'aBc123Xy');
+});
+
+test('the sweep is idempotent: a second run finds nothing to do', () => {
+  const result = pinUnpinnedServers();
+  assert.equal(result.pinned, 0);
+  // srv_wrong stays unresolved (still unpinned, still no usable evidence).
+  assert.equal(result.unresolved, 1);
+});

--- a/test/packPins.test.js
+++ b/test/packPins.test.js
@@ -6,11 +6,11 @@ const assert = require('node:assert/strict');
 const { unpinnedPackSelectors, assertPinnedPackEnv } = require('../src/services/packPins');
 
 test('pinned pack envs pass for every platform', () => {
+  assert.deepEqual(unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'all-the-mods-10', CF_FILE_ID: '5891234' }), []);
   assert.deepEqual(
-    unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'all-the-mods-10', CF_FILE_ID: '5891234' }),
+    unpinnedPackSelectors('MODRINTH', { MODRINTH_MODPACK: 'cobblemon', MODRINTH_VERSION: 'AbCd1234' }),
     []
   );
-  assert.deepEqual(unpinnedPackSelectors('MODRINTH', { MODRINTH_MODPACK: 'cobblemon', MODRINTH_VERSION: 'AbCd1234' }), []);
   assert.deepEqual(unpinnedPackSelectors('FTBA', { FTB_MODPACK_ID: '126', FTB_MODPACK_VERSION_ID: '11929' }), []);
   assert.deepEqual(unpinnedPackSelectors('GTNH', { GTNH_PACK_VERSION: '2.8.4' }), []);
   assert.doesNotThrow(() => assertPinnedPackEnv('AUTO_CURSEFORGE', { CF_SLUG: 'atm10', CF_FILE_ID: '1' }));
@@ -39,7 +39,10 @@ test('URL-embedded pins and fixed local zips count as pinned', () => {
     unpinnedPackSelectors('MODRINTH', { MODRINTH_MODPACK: 'https://modrinth.com/modpack/cobblemon/version/1.6.1' }),
     []
   );
-  assert.deepEqual(unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'atm10', CF_MODPACK_ZIP: '/packs/mine.zip' }), []);
+  assert.deepEqual(
+    unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'atm10', CF_MODPACK_ZIP: '/packs/mine.zip' }),
+    []
+  );
 });
 
 test('empty-string pins do not count as pinned', () => {

--- a/test/packPins.test.js
+++ b/test/packPins.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+require('./helpers/env');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { unpinnedPackSelectors, assertPinnedPackEnv } = require('../src/services/packPins');
+
+test('pinned pack envs pass for every platform', () => {
+  assert.deepEqual(
+    unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'all-the-mods-10', CF_FILE_ID: '5891234' }),
+    []
+  );
+  assert.deepEqual(unpinnedPackSelectors('MODRINTH', { MODRINTH_MODPACK: 'cobblemon', MODRINTH_VERSION: 'AbCd1234' }), []);
+  assert.deepEqual(unpinnedPackSelectors('FTBA', { FTB_MODPACK_ID: '126', FTB_MODPACK_VERSION_ID: '11929' }), []);
+  assert.deepEqual(unpinnedPackSelectors('GTNH', { GTNH_PACK_VERSION: '2.8.4' }), []);
+  assert.doesNotThrow(() => assertPinnedPackEnv('AUTO_CURSEFORGE', { CF_SLUG: 'atm10', CF_FILE_ID: '1' }));
+});
+
+test('unpinned selectors are detected per platform', () => {
+  assert.equal(unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'all-the-mods-10' })[0].pinKey, 'CF_FILE_ID');
+  assert.equal(
+    unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_PAGE_URL: 'https://www.curseforge.com/minecraft/modpacks/atm10' })[0]
+      .pinKey,
+    'CF_FILE_ID'
+  );
+  assert.equal(unpinnedPackSelectors('MODRINTH', { MODRINTH_MODPACK: 'cobblemon' })[0].pinKey, 'MODRINTH_VERSION');
+  assert.equal(unpinnedPackSelectors('FTBA', { FTB_MODPACK_ID: '126' })[0].pinKey, 'FTB_MODPACK_VERSION_ID');
+  assert.equal(unpinnedPackSelectors('GTNH', {})[0].pinKey, 'GTNH_PACK_VERSION');
+});
+
+test('URL-embedded pins and fixed local zips count as pinned', () => {
+  assert.deepEqual(
+    unpinnedPackSelectors('AUTO_CURSEFORGE', {
+      CF_PAGE_URL: 'https://www.curseforge.com/minecraft/modpacks/atm10/files/5891234',
+    }),
+    []
+  );
+  assert.deepEqual(
+    unpinnedPackSelectors('MODRINTH', { MODRINTH_MODPACK: 'https://modrinth.com/modpack/cobblemon/version/1.6.1' }),
+    []
+  );
+  assert.deepEqual(unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'atm10', CF_MODPACK_ZIP: '/packs/mine.zip' }), []);
+});
+
+test('empty-string pins do not count as pinned', () => {
+  assert.equal(unpinnedPackSelectors('AUTO_CURSEFORGE', { CF_SLUG: 'atm10', CF_FILE_ID: '  ' }).length, 1);
+});
+
+test('non-pack servers and selector-less pack types are left alone', () => {
+  assert.deepEqual(unpinnedPackSelectors('PAPER', { MEMORY: '4G' }), []);
+  // AUTO_CURSEFORGE with no selector at all can't auto-update anything; the
+  // container's own "no modpack given" failure is not this guard's business.
+  assert.deepEqual(unpinnedPackSelectors('AUTO_CURSEFORGE', {}), []);
+});
+
+test('assertPinnedPackEnv throws a 400 naming the missing pin', () => {
+  try {
+    assertPinnedPackEnv('AUTO_CURSEFORGE', { CF_SLUG: 'all-the-mods-10' });
+    assert.fail('expected a throw');
+  } catch (err) {
+    assert.equal(err.status, 400);
+    assert.match(err.message, /CF_FILE_ID/);
+    assert.match(err.message, /every start/);
+  }
+});

--- a/views/partials/server/settings.hbs
+++ b/views/partials/server/settings.hbs
@@ -117,12 +117,20 @@
       </div>
     </div>
 
+    {{#if server.packUnpinned}}
+    <div class="notice notice-warn max-w-prose text-sm">
+      <b>This modpack has no pinned version.</b> The container downloads the newest pack version every time it
+      starts - which can silently change your mods and even your world's Minecraft version. Open the
+      <b>Modpack</b> section and pick the version you're running to lock it in.
+    </div>
+    {{/if}}
+
     <div class="card p-4">
       <h3 class="mb-3 font-semibold">Update Policy</h3>
       <div class="space-y-2 text-sm">
-        <label class="flex items-center gap-2.5"><input type="radio" name="up" value="manual" class="msm-radio" {{#if (eq server.updatePolicy 'manual')}}checked{{/if}}> Manual only <span class="text-xs text-ink-faint">(never change my versions)</span></label>
-        <label class="flex items-center gap-2.5"><input type="radio" name="up" value="notify" class="msm-radio" {{#if (eq server.updatePolicy 'notify')}}checked{{/if}}> Notify me <span class="text-xs text-ink-faint">(show a badge when updates exist)</span></label>
-        <label class="flex items-center gap-2.5"><input type="radio" name="up" value="auto" class="msm-radio" {{#if (eq server.updatePolicy 'auto')}}checked{{/if}}> Auto-update <span class="text-xs text-ink-faint">(with an automatic pre-update backup)</span></label>
+        <label class="flex items-center gap-2.5"><input type="radio" name="up" value="manual" class="msm-radio" {{#if (eq server.updatePolicy 'manual')}}checked{{/if}}> Manual only <span class="text-xs text-ink-faint">(never changes anything, and no update badges for this server)</span></label>
+        <label class="flex items-center gap-2.5"><input type="radio" name="up" value="notify" class="msm-radio" {{#if (eq server.updatePolicy 'notify')}}checked{{/if}}> Notify me <span class="text-xs text-ink-faint">(show a badge when updates exist; you apply them)</span></label>
+        <label class="flex items-center gap-2.5"><input type="radio" name="up" value="auto" class="msm-radio" {{#if (eq server.updatePolicy 'auto')}}checked{{/if}}> Auto-update <span class="text-xs text-ink-faint">(applies pack updates after the daily check: pre-update backup, health check, automatic rollback on failure - never across Minecraft versions)</span></label>
       </div>
     </div>
 


### PR DESCRIPTION
Closes #22, closes #24.

## What was actually wrong (#22)

The panel has pinned every modpack install to an exact version since 0.9.7 — but servers created **before** that (or with hand-edited env) still carry a pack selector with no pin (`CF_SLUG` without `CF_FILE_ID`, `MODRINTH_MODPACK` without `MODRINTH_VERSION`, …). For those, the container image resolves **the newest pack file on every single start**: silent updates, wrong versions, and the forced-reinstall spiral that lost worlds in #21. Nothing migrated, guarded, or even warned about that state.

On the "old files left behind" half: the image's installer cleans up files from previous pack versions on its own (per its docs) *when moving between known versions* — the leftovers people see come from the unpinned flip-flopping and crashed mid-installs, which this PR makes impossible. No panel-side file deletion was added on purpose: blind cleanup next to world data is a worse risk than the mess it tidies.

## The fix

- **Boot sweep** (`packPins.pinUnpinnedServers`): every unpinned server gets locked to the version that is *actually installed*, sourced from the panel's own `server_packs` record or the image's install manifest (`.curseforge-manifest.json` / `.modrinth-manifest.json`, slug cross-checked so a stale manifest can't mis-pin). Never a freshly resolved "latest". CF manifests also backfill the `server_packs` row, so legacy servers join the guarded upgrade + update-check flows. Pins are evented and the container is flagged for recreate.
- **No evidence → no guess**: the server's Settings page shows a warning with a manual version pick.
- **Write guards**: create, config update, and blueprint import now reject an unpinned pack selector with a clear 400, so the state can't come back.

## The update policy is now real (#24)

`update_policy` (manual/notify/auto) was stored, rendered as radios promising "Auto-update (with an automatic pre-update backup)" — and consumed by *nothing*. Now:

- **Manual only** — never changes anything **and** the server is excluded from the update badge, the Updates page, and the daily check's notifications. The real "leave my imported pack alone" mode requested in #21/#24. Check rows still refresh so flipping back shows current state instantly.
- **Notify** — unchanged (badge + Updates page), still the default.
- **Auto** — after the **scheduled** daily check only (manual "check now" buttons never apply anything), pending pack updates go through the existing safe orchestrator: pre-update backup, health monitoring, and **automatic rollback** when the new version fails to boot. Cross-MC-version updates are always skipped with an event — world conversion stays a human decision. Packs only for now; image/loader auto-updates would be a follow-up.

Radio copy and `docs/modpacks.md` updated to say exactly this. Also adds the community Discord banner to the README.

## Testing

- New: `packPins` unit tests, boot-sweep integration tests (manifest pin, DB-record pin, slug mismatch distrust, idempotency), manual-policy filter tests, auto-upgrade guardrail tests (never touches manual/notify/up-to-date/packless servers).
- Full suite: 462/463 — the 1 failure is the pre-existing pathGuard symlink baseline on this machine, unrelated. Lint + typecheck clean.
- Live end-to-end: booted the panel against a fabricated pre-0.9.7 server (unpinned `CF_SLUG` + real-shape install manifest) — the sweep pinned it (`CF_FILE_ID=5544332`), backfilled `server_packs`, recorded the `pack-pinned` event, flagged recreate, and the panel came up healthy.

## Note for #21 reporters

@supersynx's 0.9.8 servers get auto-pinned to their installed version the moment they upgrade MSM — no action needed, and a history event shows exactly what was locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)