### PR TITLE
docs: record the main branch protection gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,12 @@ pnpm run build         # Tailwind CSS + esbuild client-JS bundle
 test:smoke` is the separate live sweep against a running panel. While iterating on a change, `pnpm run
 test:watch` re-runs the suite on every save.
 
+`main` is protected: the CI job `quality` (all five gates above) is a required status check, the PR
+branch must be up to date with `main`, and direct pushes, force pushes and deletion are blocked for
+everyone including admins. Every change - releases too - lands through a PR, which is what keeps the
+`:latest` image and GitHub Release workflows (both fire on push to `main`) from ever publishing an
+untested commit.
+
 Keep changes focused and match the surrounding style (Prettier enforces it). Server code is **plain
 CommonJS JS - no TypeScript compile step**. The browser code in `public/js/` is ESM, bundled and
 minified by **esbuild** into `public/dist/js/` for production; it is not a framework and not a build


### PR DESCRIPTION
Follow-up to #33. Branch protection is now enabled on `main` (required `quality` check, up-to-date branches, no direct/force pushes, enforced for admins). This documents it in CONTRIBUTING so contributors know why a PR is the only way in, and doubles as the first PR to go through the gate.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)